### PR TITLE
feat: add `list` command

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -114,6 +114,10 @@ pub async fn list(
             println!("{}", serde_yaml::to_string(&filtered_items)?);
         }
         OutputFormat::Table => {
+            // Display server name in italics above the table
+            let server_url = config.server_url()?;
+            println!("{}", server_url.italic().dimmed());
+            
             if filtered_items.is_empty() {
                 println!("{}", "No content items found".yellow());
                 return Ok(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,11 @@ struct Cli {
     command: Commands,
 
     /// Server URL (can also be set with RICOCHET_SERVER environment variable)
-    #[arg(global = true, long, env = "RICOCHET_SERVER")]
+    #[arg(global = true, short = 'S', long, env = "RICOCHET_SERVER")]
     server: Option<String>,
 
     /// Output format
-    #[arg(global = true, long, default_value = "table", value_enum)]
+    #[arg(global = true, short = 'F', long, default_value = "table", value_enum)]
     format: OutputFormat,
 }
 
@@ -23,7 +23,7 @@ enum Commands {
     /// Authenticate with the Ricochet server
     Login {
         /// API key (can also be provided interactively)
-        #[arg(long)]
+        #[arg(short = 'k', long)]
         api_key: Option<String>,
     },
     /// Remove stored credentials
@@ -34,20 +34,24 @@ enum Commands {
         #[arg(default_value = ".")]
         path: std::path::PathBuf,
         /// Name for the deployment
-        #[arg(long)]
+        #[arg(short = 'n', long)]
         name: Option<String>,
         /// Description for the deployment
-        #[arg(long)]
+        #[arg(short = 'd', long)]
         description: Option<String>,
     },
     /// List all content items
     List {
         /// Filter by content type
-        #[arg(long)]
+        #[arg(short = 't', long)]
         content_type: Option<String>,
-        /// Show only active deployments
-        #[arg(long)]
+        /// Show only active deployments (status: deployed, running, or success)
+        #[arg(short = 'a', long)]
         active_only: bool,
+        /// Sort by field(s) - comma-separated for multiple (e.g., "name,updated" or "status,name")
+        /// Prefix with '-' for descending order (e.g., "-updated,name")
+        #[arg(short = 's', long)]
+        sort: Option<String>,
     },
     /// Get status of a content item
     Status {
@@ -59,7 +63,7 @@ enum Commands {
         /// Content item ID (ULID)
         id: String,
         /// Parameters as JSON
-        #[arg(long)]
+        #[arg(short = 'p', long)]
         params: Option<String>,
     },
     /// Stop a running service or invocation
@@ -67,7 +71,7 @@ enum Commands {
         /// Content item ID (ULID)
         id: String,
         /// Instance PID (for services) or invocation ID
-        #[arg(long)]
+        #[arg(short = 'i', long)]
         instance: Option<String>,
     },
     /// Delete a content item
@@ -75,7 +79,7 @@ enum Commands {
         /// Content item ID (ULID)
         id: String,
         /// Skip confirmation
-        #[arg(long)]
+        #[arg(short = 'f', long)]
         force: bool,
     },
     /// Manage content schedules
@@ -83,10 +87,10 @@ enum Commands {
         /// Content item ID (ULID)
         id: String,
         /// Cron expression (e.g., "0 0 * * *" for daily at midnight)
-        #[arg(long)]
+        #[arg(short = 'c', long)]
         cron: Option<String>,
         /// Disable the schedule
-        #[arg(long)]
+        #[arg(short = 'D', long)]
         disable: bool,
     },
     /// Update content settings
@@ -94,13 +98,13 @@ enum Commands {
         /// Content item ID (ULID)
         id: String,
         /// Update settings as JSON
-        #[arg(long)]
+        #[arg(short = 'u', long)]
         update: String,
     },
     /// Show configuration
     Config {
         /// Show full configuration including sensitive values
-        #[arg(long)]
+        #[arg(short = 'A', long)]
         show_all: bool,
     },
     /// Generate markdown documentation (hidden command)
@@ -138,8 +142,9 @@ async fn main() -> Result<()> {
         Commands::List {
             content_type,
             active_only,
+            sort,
         } => {
-            commands::list::list(&config, content_type, active_only, cli.format).await?;
+            commands::list::list(&config, content_type, active_only, sort, cli.format).await?;
         }
         Commands::Status { id } => {
             commands::status::status(&config, &id, cli.format).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,11 @@ struct Cli {
     command: Commands,
 
     /// Server URL (can also be set with RICOCHET_SERVER environment variable)
-    #[arg(global = true, short = 'S', long, env = "RICOCHET_SERVER")]
+    #[arg(global = true, short = 'S', long, env = "RICOCHET_SERVER", help_heading = "Global Options")]
     server: Option<String>,
 
     /// Output format
-    #[arg(global = true, short = 'F', long, default_value = "table", value_enum)]
+    #[arg(global = true, short = 'F', long, default_value = "table", value_enum, help_heading = "Global Options")]
     format: OutputFormat,
 }
 

--- a/test_list_output.sh
+++ b/test_list_output.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Test script to verify list output format
+
+echo "Testing list command with JSON format to see field names:"
+echo "=========================================================="
+target/release/ricochet list --format json | jq '.[0] | keys' 2>/dev/null || echo "No items or jq not installed"
+
+echo ""
+echo "Sample item structure (first item):"
+echo "===================================="
+target/release/ricochet list --format json | jq '.[0]' 2>/dev/null || echo "No items or jq not installed"

--- a/tests/list_test.rs
+++ b/tests/list_test.rs
@@ -51,6 +51,7 @@ mod list_tests {
             &config,
             None,
             false,
+            None, // no sorting
             ricochet_cli::OutputFormat::Json,
         )
         .await;
@@ -95,6 +96,7 @@ mod list_tests {
             &config,
             None,
             false,
+            None, // no sorting
             ricochet_cli::OutputFormat::Table,
         )
         .await;
@@ -150,6 +152,7 @@ mod list_tests {
             &config,
             Some("shiny".to_string()),
             false,
+            None, // no sorting
             ricochet_cli::OutputFormat::Json,
         )
         .await;
@@ -161,6 +164,7 @@ mod list_tests {
             &config,
             None,
             true,
+            None, // no sorting
             ricochet_cli::OutputFormat::Json,
         )
         .await;
@@ -192,6 +196,7 @@ mod list_tests {
             &config,
             None,
             false,
+            None, // no sorting
             ricochet_cli::OutputFormat::Table,
         )
         .await;

--- a/tests/list_test.rs
+++ b/tests/list_test.rs
@@ -1,0 +1,201 @@
+use mockito::Server;
+use serde_json::json;
+
+#[cfg(test)]
+mod list_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_list_json_format() {
+        // Create mock server
+        let mut server = Server::new_async().await;
+
+        // Mock the server response for list items
+        let _m = server.mock("GET", "/api/v0/user/items")
+            .match_header("authorization", "Key test_api_key")
+            .with_status(200)
+            .with_body(
+                json!([
+                    {
+                        "id": "01K66JV2Q123456789ABCDEF",
+                        "name": "Metadata Dashboard",
+                        "content_type": "shiny",
+                        "language": "R",
+                        "visibility": "private",
+                        "status": "deployed",
+                        "updated_at": "2024-01-15T10:30:00Z"
+                    },
+                    {
+                        "id": "01K66JV2Q987654321FEDCBA",
+                        "name": "API Service",
+                        "content_type": "api",
+                        "language": "Python",
+                        "visibility": "public",
+                        "status": "running",
+                        "updated_at": "2024-01-16T14:20:00Z"
+                    }
+                ])
+                .to_string(),
+            )
+            .create();
+
+        // Create test config
+        let config = ricochet_cli::config::Config {
+            server: Some(server.url()),
+            api_key: Some("test_api_key".to_string()),
+            default_format: Some("table".to_string()),
+        };
+
+        // Test JSON output format
+        let result = ricochet_cli::commands::list::list(
+            &config,
+            None,
+            false,
+            ricochet_cli::OutputFormat::Json,
+        )
+        .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_list_table_format_no_truncation() {
+        // Create mock server
+        let mut server = Server::new_async().await;
+
+        // Mock the server response with long names and IDs
+        let _m = server.mock("GET", "/api/v0/user/items")
+            .match_header("authorization", "Key test_api_key")
+            .with_status(200)
+            .with_body(
+                json!([
+                    {
+                        "id": "01K66JV2Q123456789ABCDEFGHIJKLMNOP",
+                        "name": "This is a very long content item name that should not be truncated in the output",
+                        "content_type": "shiny",
+                        "language": "R",
+                        "visibility": "private",
+                        "status": "deployed",
+                        "updated_at": "2024-01-15T10:30:00Z"
+                    }
+                ])
+                .to_string(),
+            )
+            .create();
+
+        // Create test config
+        let config = ricochet_cli::config::Config {
+            server: Some(server.url()),
+            api_key: Some("test_api_key".to_string()),
+            default_format: Some("table".to_string()),
+        };
+
+        // Test table output format - should not truncate
+        let result = ricochet_cli::commands::list::list(
+            &config,
+            None,
+            false,
+            ricochet_cli::OutputFormat::Table,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        // The actual output verification would require capturing stdout,
+        // but the test ensures no panic occurs with long values
+    }
+
+    #[tokio::test]
+    async fn test_list_with_filters() {
+        // Create mock server
+        let mut server = Server::new_async().await;
+
+        // Mock the server response
+        let _m = server.mock("GET", "/api/v0/user/items")
+            .match_header("authorization", "Key test_api_key")
+            .with_status(200)
+            .with_body(
+                json!([
+                    {
+                        "id": "01K66JV2Q123",
+                        "name": "Shiny App",
+                        "content_type": "shiny",
+                        "language": "R",
+                        "visibility": "private",
+                        "status": "deployed",
+                        "updated_at": "2024-01-15T10:30:00Z"
+                    },
+                    {
+                        "id": "01K66JV2Q456",
+                        "name": "API",
+                        "content_type": "api",
+                        "language": "Python",
+                        "visibility": "public",
+                        "status": "failed",
+                        "updated_at": "2024-01-16T14:20:00Z"
+                    }
+                ])
+                .to_string(),
+            )
+            .create();
+
+        // Create test config
+        let config = ricochet_cli::config::Config {
+            server: Some(server.url()),
+            api_key: Some("test_api_key".to_string()),
+            default_format: Some("table".to_string()),
+        };
+
+        // Test filtering by content type
+        let result = ricochet_cli::commands::list::list(
+            &config,
+            Some("shiny".to_string()),
+            false,
+            ricochet_cli::OutputFormat::Json,
+        )
+        .await;
+
+        assert!(result.is_ok());
+
+        // Test filtering by active only
+        let result2 = ricochet_cli::commands::list::list(
+            &config,
+            None,
+            true,
+            ricochet_cli::OutputFormat::Json,
+        )
+        .await;
+
+        assert!(result2.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_list_empty_response() {
+        // Create mock server
+        let mut server = Server::new_async().await;
+
+        // Mock empty response
+        let _m = server.mock("GET", "/api/v0/user/items")
+            .match_header("authorization", "Key test_api_key")
+            .with_status(200)
+            .with_body(json!([]).to_string())
+            .create();
+
+        // Create test config
+        let config = ricochet_cli::config::Config {
+            server: Some(server.url()),
+            api_key: Some("test_api_key".to_string()),
+            default_format: Some("table".to_string()),
+        };
+
+        // Test empty list
+        let result = ricochet_cli::commands::list::list(
+            &config,
+            None,
+            false,
+            ricochet_cli::OutputFormat::Table,
+        )
+        .await;
+
+        assert!(result.is_ok());
+    }
+}


### PR DESCRIPTION



```
ricochet list
https://dev.k8s.ricochet.rs
┌────────────────────────────┬────────────────────┬───────┬──────────┬────────────┬─────────┬─────────┐
│ ID                         ┆ Name               ┆ Type  ┆ Language ┆ Visibility ┆ Status  ┆ Updated │
╞════════════════════════════╪════════════════════╪═══════╪══════════╪════════════╪═════════╪═════════╡
│ 01K66JV2QEX866MQPSBP35EHWB ┆ Metadata Dashboard ┆ shiny ┆ r        ┆ private    ┆ failure ┆ -       │
└────────────────────────────┴────────────────────┴───────┴──────────┴────────────┴─────────┴─────────┘

1 total items
```

```
ricochet-dev list --format json
[
  {
    "access_type": "private",
    "content_type": "shiny",
    "created_at": 1759010196,
    "deployed_at": 1759010196,
    "deployment_id": "01K66JV2QX1C8DJKHDTYXGFY9V",
    "deployment_status": "failure",
    "id": "01K66JV2QEX866MQPSBP35EHWB",
    "language": "r",
    "modified_at": 1759010196,
    "name": "Metadata Dashboard",
    "role": "owner",
    "slug": null,
    "summary": null,
    "tags": null,
    "thumbnail": null
  }
]
```

```
ricochet-dev list -h
List all content items

Usage: ricochet-dev list [OPTIONS]

Options:
  -t, --content-type <CONTENT_TYPE>  Filter by content type
  -a, --active-only                  Show only active deployments (status: deployed, running, or success)
  -s, --sort <SORT>                  Sort by field(s) - comma-separated for multiple (e.g., "name,updated" or "status,name") Prefix with '-' for descending order (e.g., "-updated,name")
  -h, --help                         Print help

Global Options:
  -S, --server <SERVER>  Server URL (can also be set with RICOCHET_SERVER environment variable) [env: RICOCHET_SERVER=https://dev.k8s.ricochet.rs]
  -F, --format <FORMAT>  Output format [default: table] [possible values: table, json, yaml]
```