### PR TITLE
fix: login with trailing slash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ tokio-util = { version = "0.7", features = ["io"] }
 toml = "0.9"
 ulid = "1.1"
 unicode-icons = "2.0"
-url = "2.5"
+url = { version = "2.5", features = ["serde"] }
 urlencoding = "2.1"
 walkdir = "2.5"
 webbrowser = "1.0"

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -8,11 +8,7 @@ pub fn show(config: &Config, show_all: bool) -> Result<()> {
     println!("Config file: {}", Config::config_path()?.display());
     println!();
 
-    if let Some(server) = &config.server {
-        println!("Server URL: {}", server.bright_cyan());
-    } else {
-        println!("Server URL: {}", "Not configured".yellow());
-    }
+    println!("Server URL: {}", config.server.as_str().bright_cyan());
 
     if let Some(api_key) = &config.api_key {
         if show_all {

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -30,9 +30,7 @@ pub async fn deploy(
         // Check if we're in an interactive terminal
         if std::io::stdin().is_terminal() {
             let confirmed = Confirm::with_theme(&ColorfulTheme::default())
-                .with_prompt(format!(
-                    "No _ricochet.toml found. Would you like to create one?"
-                ))
+                .with_prompt("No _ricochet.toml found. Would you like to create one?")
                 .default(true)
                 .interact()?;
 
@@ -116,7 +114,7 @@ pub async fn deploy(
 
                 // Get server URL and construct links
                 let server_url = config.server_url()?;
-                let base_url = server_url.trim_end_matches('/');
+                let base_url = server_url.as_str().trim_end_matches('/');
 
                 println!("\n{}", "Links:".bold());
 
@@ -162,7 +160,7 @@ pub async fn deploy(
                 );
                 eprintln!(
                     "    2. Check if you're connected to the correct server: {}",
-                    config.server_url().unwrap_or_default().bright_cyan()
+                    config.server.as_str().bright_cyan()
                 );
                 eprintln!(
                     "    3. Remove the 'id' field from _ricochet.toml to create a new content item instead"

--- a/src/commands/invoke.rs
+++ b/src/commands/invoke.rs
@@ -22,7 +22,7 @@ pub async fn invoke(config: &Config, id: &str, format: OutputFormat) -> Result<(
                 OutputFormat::Table => {
                     // Display server name in italics above the table
                     let server_url = config.server_url()?;
-                    println!("{}", server_url.italic().dimmed());
+                    println!("{}", server_url.as_str().italic().dimmed());
 
                     let mut table = Table::new();
                     table.load_preset(UTF8_FULL);

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -118,7 +118,7 @@ pub async fn list(
         OutputFormat::Table => {
             // Display server name in italics above the table
             let server_url = config.server_url()?;
-            println!("{}", server_url.italic().dimmed());
+            println!("{}", server_url.as_str().italic().dimmed());
 
             if filtered_items.is_empty() {
                 println!("{}", "No content items found".yellow());

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,22 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use url::Url;
+
+/// Parse a server URL with validation that it includes the http:// or https:// scheme
+pub fn parse_server_url(url_str: &str) -> Result<Url> {
+    if !url_str.starts_with("http://") && !url_str.starts_with("https://") {
+        anyhow::bail!(
+            "Server URL must include the scheme prefix (http:// or https://). Got: '{}'",
+            url_str
+        )
+    }
+    Url::parse(url_str).context("Invalid server URL format")
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
-    pub server: Option<String>,
+    pub server: Url,
     pub api_key: Option<String>,
     pub default_format: Option<String>,
 }
@@ -12,7 +24,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            server: Some("http://localhost:3000".to_string()),
+            server: Url::parse("http://localhost:3000").unwrap(),
             api_key: None,
             default_format: Some("table".to_string()),
         }
@@ -51,11 +63,13 @@ impl Config {
         Ok(config_dir.join("ricochet").join("config.toml"))
     }
 
-    pub fn server_url(&self) -> Result<String> {
-        self.server
-            .clone()
-            .or_else(|| std::env::var("RICOCHET_SERVER").ok())
-            .context("No server configured. Use 'ricochet login' or set RICOCHET_SERVER")
+    pub fn server_url(&self) -> Result<Url> {
+        if let Ok(server_env) = std::env::var("RICOCHET_SERVER") {
+            parse_server_url(&server_env)
+                .context("Invalid URL in RICOCHET_SERVER environment variable")
+        } else {
+            Ok(self.server.clone())
+        }
     }
 
     pub fn api_key(&self) -> Result<String> {
@@ -63,5 +77,16 @@ impl Config {
             .ok()
             .or_else(|| self.api_key.clone())
             .context("No API key configured. Use 'ricochet login' to authenticate")
+    }
+
+    pub fn build_authorize_url(&self, callback_url: &str) -> Result<Url> {
+        let mut oauth_url = self.server_url()?;
+        oauth_url.set_path("/oauth/authorize");
+        oauth_url
+            .query_pairs_mut()
+            .append_pair("redirect_uri", callback_url)
+            .append_pair("response_type", "code")
+            .append_pair("client_id", "cli");
+        Ok(oauth_url)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,9 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
-use ricochet_cli::{OutputFormat, commands, config::Config};
+use ricochet_cli::{
+    OutputFormat, commands,
+    config::{Config, parse_server_url},
+};
 
 #[derive(Parser)]
 #[command(name = "ricochet")]
@@ -123,10 +126,10 @@ async fn main() -> Result<()> {
         let build_date = env!("BUILD_DATE");
 
         if has_tag == "true" || git_hash.is_empty() {
-            // Tagged release or not in git repo - just show version
+            // Tagged release
             println!("{}", version);
         } else {
-            // Untagged build - append git hash and build date
+            // Untagged build
             println!("{}-{} ({})", version, git_hash, build_date);
         }
         return Ok(());
@@ -137,7 +140,7 @@ async fn main() -> Result<()> {
 
     // Override server if provided via CLI
     if let Some(server) = cli.server {
-        config.server = Some(server);
+        config.server = parse_server_url(&server)?;
     }
 
     // Execute command

--- a/tests/delete_test.rs
+++ b/tests/delete_test.rs
@@ -1,5 +1,6 @@
 use mockito::Server;
 use serde_json::json;
+use url::Url;
 
 #[cfg(test)]
 mod delete_tests {
@@ -20,7 +21,7 @@ mod delete_tests {
 
         // Create test config
         let config = ricochet_cli::config::Config {
-            server: Some(server.url()),
+            server: Url::parse(&server.url()).unwrap(),
             api_key: Some("test_api_key".to_string()),
             default_format: Some("table".to_string()),
         };
@@ -47,7 +48,7 @@ mod delete_tests {
 
         // Create test config
         let config = ricochet_cli::config::Config {
-            server: Some(server.url()),
+            server: Url::parse(&server.url()).unwrap(),
             api_key: Some("test_api_key".to_string()),
             default_format: Some("table".to_string()),
         };
@@ -76,7 +77,7 @@ mod delete_tests {
 
         // Create test config with invalid key
         let config = ricochet_cli::config::Config {
-            server: Some(server.url()),
+            server: Url::parse(&server.url()).unwrap(),
             api_key: Some("invalid_key".to_string()),
             default_format: Some("table".to_string()),
         };
@@ -103,7 +104,7 @@ mod delete_tests {
 
         // Create test config
         let config = ricochet_cli::config::Config {
-            server: Some(server.url()),
+            server: Url::parse(&server.url()).unwrap(),
             api_key: Some("test_api_key".to_string()),
             default_format: Some("table".to_string()),
         };
@@ -131,7 +132,7 @@ mod delete_tests {
             .create();
 
         let config = ricochet_cli::config::Config {
-            server: Some(server.url()),
+            server: Url::parse(&server.url()).unwrap(),
             api_key: Some("test_api_key".to_string()),
             default_format: Some("table".to_string()),
         };
@@ -168,7 +169,7 @@ mod delete_tests {
             .create();
 
         let config = ricochet_cli::config::Config {
-            server: Some(server.url()),
+            server: Url::parse(&server.url()).unwrap(),
             api_key: Some("test_api_key".to_string()),
             default_format: Some("table".to_string()),
         };

--- a/tests/deploy_test.rs
+++ b/tests/deploy_test.rs
@@ -3,6 +3,7 @@ use serde_json::json;
 use std::fs;
 use std::path::Path;
 use tempfile::TempDir;
+use url::Url;
 
 #[cfg(test)]
 mod deploy_tests {
@@ -81,7 +82,7 @@ shinyApp(ui = ui, server = server)"#,
 
         // Create test config
         let config = ricochet_cli::config::Config {
-            server: Some(server.url()),
+            server: Url::parse(&server.url()).unwrap(),
             api_key: Some("test_api_key".to_string()),
             default_format: Some("table".to_string()),
         };
@@ -137,7 +138,7 @@ shinyApp(ui = ui, server = server)"#,
 
         // Create test config
         let config = ricochet_cli::config::Config {
-            server: Some(server.url()),
+            server: Url::parse(&server.url()).unwrap(),
             api_key: Some("test_api_key".to_string()),
             default_format: Some("table".to_string()),
         };
@@ -169,17 +170,13 @@ shinyApp(ui = ui, server = server)"#,
         let temp_dir = TempDir::new().unwrap();
         let project_path = temp_dir.path();
 
-        // Create mock server (not used but needed for config)
-        let server = Server::new_async().await;
-
         // Create test config
         let config = ricochet_cli::config::Config {
-            server: Some(server.url()),
+            server: Url::parse("http://localhost:3000").unwrap(),
             api_key: Some("test_api_key".to_string()),
             default_format: Some("table".to_string()),
         };
 
-        // Run deploy command - should fail
         let result = ricochet_cli::commands::deploy::deploy(
             &config,
             project_path.to_path_buf(),
@@ -189,12 +186,13 @@ shinyApp(ui = ui, server = server)"#,
         )
         .await;
 
+        dbg!(&result);
         assert!(result.is_err());
         assert!(
             result
                 .unwrap_err()
                 .to_string()
-                .contains("No _ricochet.toml found")
+                .contains("No _ricochet.toml")
         );
     }
 
@@ -218,7 +216,7 @@ key = "value"
 
         // Create test config
         let config = ricochet_cli::config::Config {
-            server: Some(server.url()),
+            server: Url::parse(&server.url()).unwrap(),
             api_key: Some("test_api_key".to_string()),
             default_format: Some("table".to_string()),
         };
@@ -256,7 +254,7 @@ key = "value"
 
         // Create test config with invalid key
         let config = ricochet_cli::config::Config {
-            server: Some(server.url()),
+            server: Url::parse(&server.url()).unwrap(),
             api_key: Some("invalid_key".to_string()),
             default_format: Some("table".to_string()),
         };
@@ -313,7 +311,7 @@ key = "value"
             .create();
 
         let config = ricochet_cli::config::Config {
-            server: Some(server.url()),
+            server: Url::parse(&server.url()).unwrap(),
             api_key: Some("test_api_key".to_string()),
             default_format: Some("table".to_string()),
         };
@@ -368,7 +366,7 @@ key = "value"
             .create();
 
         let config = ricochet_cli::config::Config {
-            server: Some(server.url()),
+            server: Url::parse(&server.url()).unwrap(),
             api_key: Some("test_api_key".to_string()),
             default_format: Some("table".to_string()),
         };

--- a/tests/invoke_test.rs
+++ b/tests/invoke_test.rs
@@ -1,5 +1,6 @@
 use mockito::{Matcher, Server};
 use serde_json::json;
+use url::Url;
 
 #[cfg(test)]
 mod invoke_tests {
@@ -31,7 +32,7 @@ mod invoke_tests {
             .create();
 
         let config = ricochet_cli::config::Config {
-            server: Some(server.url()),
+            server: Url::parse(&server.url()).unwrap(),
             api_key: Some("test_api_key".to_string()),
             default_format: Some("table".to_string()),
         };
@@ -68,7 +69,7 @@ mod invoke_tests {
 
         // Create test config with invalid key
         let config = ricochet_cli::config::Config {
-            server: Some(server.url()),
+            server: Url::parse(&server.url()).unwrap(),
             api_key: Some("invalid_key".to_string()),
             default_format: Some("table".to_string()),
         };
@@ -104,7 +105,7 @@ mod invoke_tests {
 
         // Create test config
         let config = ricochet_cli::config::Config {
-            server: Some(server.url()),
+            server: Url::parse(&server.url()).unwrap(),
             api_key: Some("test_api_key".to_string()),
             default_format: Some("table".to_string()),
         };
@@ -149,7 +150,7 @@ mod invoke_tests {
             .create();
 
         let config = ricochet_cli::config::Config {
-            server: Some(server.url()),
+            server: Url::parse(&server.url()).unwrap(),
             api_key: Some("test_api_key".to_string()),
             default_format: Some("json".to_string()),
         };
@@ -197,7 +198,7 @@ mod invoke_tests {
             .create();
 
         let config = ricochet_cli::config::Config {
-            server: Some(server.url()),
+            server: Url::parse(&server.url()).unwrap(),
             api_key: Some("test_api_key".to_string()),
             default_format: Some("yaml".to_string()),
         };

--- a/tests/list_test.rs
+++ b/tests/list_test.rs
@@ -1,5 +1,6 @@
 use mockito::Server;
 use serde_json::json;
+use url::Url;
 
 #[cfg(test)]
 mod list_tests {
@@ -42,7 +43,7 @@ mod list_tests {
 
         // Create test config
         let config = ricochet_cli::config::Config {
-            server: Some(server.url()),
+            server: Url::parse(&server.url()).unwrap(),
             api_key: Some("test_api_key".to_string()),
             default_format: Some("table".to_string()),
         };
@@ -87,7 +88,7 @@ mod list_tests {
 
         // Create test config
         let config = ricochet_cli::config::Config {
-            server: Some(server.url()),
+            server: Url::parse(&server.url()).unwrap(),
             api_key: Some("test_api_key".to_string()),
             default_format: Some("table".to_string()),
         };
@@ -144,7 +145,7 @@ mod list_tests {
 
         // Create test config
         let config = ricochet_cli::config::Config {
-            server: Some(server.url()),
+            server: Url::parse(&server.url()).unwrap(),
             api_key: Some("test_api_key".to_string()),
             default_format: Some("table".to_string()),
         };
@@ -189,7 +190,7 @@ mod list_tests {
 
         // Create test config
         let config = ricochet_cli::config::Config {
-            server: Some(server.url()),
+            server: Url::parse(&server.url()).unwrap(),
             api_key: Some("test_api_key".to_string()),
             default_format: Some("table".to_string()),
         };


### PR DESCRIPTION
This PR changes the `RicochetClient` and `Config` to use a `url::Url` to perform url validation and path & query modification. This means that we can now use a trailing slash for example `ricochet login -S https://dev.vm.ubuntu.ricochet.rs/`

