### PR TITLE
chore: bump install script versions

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -4,7 +4,7 @@
 $ErrorActionPreference = 'Stop'
 
 # Configuration
-$Version = if ($env:RICOCHET_VERSION) { $env:RICOCHET_VERSION } else { "0.1.0" }
+$Version = if ($env:RICOCHET_VERSION) { $env:RICOCHET_VERSION } else { "0.2.0" }
 $InstallDir = if ($env:RICOCHET_INSTALL_DIR) { $env:RICOCHET_INSTALL_DIR } else { "$HOME\bin" }
 $GithubReleasesBase = "https://github.com/ricochet-rs/cli/releases/download/v$Version"
 

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-VERSION="${RICOCHET_VERSION:-0.1.0}"
+VERSION="${RICOCHET_VERSION:-0.2.0}"
 INSTALL_DIR="${RICOCHET_INSTALL_DIR:-/usr/local/bin}"
 GITHUB_RELEASES_BASE="https://github.com/ricochet-rs/cli/releases/download/v${VERSION}"
 S3_BASE_URL="https://hel1.your-objectstorage.com/ricochet-cli/v${VERSION}"


### PR DESCRIPTION
This PR bumps the versions referenced in the install scripts `install.sh` and `install.ps1`. 