### PR TITLE
enh: prompt for server input when `RICOCHET_SERVER` is unset

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,17 @@ impl Config {
         }
     }
 
+    /// Check if the server URL is explicitly configured (via env var or non-default config)
+    pub fn has_explicit_server(&self) -> bool {
+        // Check env var first
+        if std::env::var("RICOCHET_SERVER").is_ok() {
+            return true;
+        }
+        // Check if config server differs from default
+        let default_server = Url::parse("http://localhost:3000").unwrap();
+        self.server != default_server
+    }
+
     pub fn api_key(&self) -> Result<String> {
         std::env::var("RICOCHET_API_KEY")
             .ok()


### PR DESCRIPTION
OLD (leads to immediate browser redirect):

```
ricochet login
🔐 Authenticating against ricochet server


Starting OAuth authentication...

Opening browser for authentication...
If browser doesn't open, visit:
  http://localhost:3000/oauth/authorize?redirect_uri=http%3A%2F%2Flocalhost%3A60282%2Fcallback&response_type=code&client_id=cli

Waiting for authentication...
```


NEW (prompts for input):

```
ricochet login
⚠ No server URL configured.
Set RICOCHET_SERVER environment variable or enter a server URL below.
Server URL (e.g., https://ricochet.example.com): ⏎
```