### PR TITLE
chore: rename self-update -> self update

### DIFF
--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -18,7 +18,9 @@ This document contains the help content for the `ricochet` command-line program.
 * [`ricochet servers add`↴](#ricochet-servers-add)
 * [`ricochet servers remove`↴](#ricochet-servers-remove)
 * [`ricochet servers set-default`↴](#ricochet-servers-set-default)
-* [`ricochet self-update`↴](#ricochet-self-update)
+* [`ricochet self`↴](#ricochet-self)
+* [`ricochet self update`↴](#ricochet-self-update)
+* [`ricochet self version`↴](#ricochet-self-version)
 
 ## `ricochet`
 
@@ -37,7 +39,7 @@ Ricochet CLI
 * `config` — Show configuration
 * `init` — Initialize a new Ricochet deployment
 * `servers` — Manage configured Ricochet servers
-* `self-update` — Update the ricochet CLI to the latest version
+* `self` — Manage the ricochet CLI itself
 
 ###### **Options:**
 
@@ -233,15 +235,36 @@ Set the default server
 
 
 
-## `ricochet self-update`
+## `ricochet self`
+
+Manage the ricochet CLI itself
+
+**Usage:** `ricochet self <COMMAND>`
+
+###### **Subcommands:**
+
+* `update` — Update the ricochet CLI to the latest version
+* `version` — Print the current version
+
+
+
+## `ricochet self update`
 
 Update the ricochet CLI to the latest version
 
-**Usage:** `ricochet self-update [OPTIONS]`
+**Usage:** `ricochet self update [OPTIONS]`
 
 ###### **Options:**
 
 * `-f`, `--force` — Force reinstall even if already on the latest version
+
+
+
+## `ricochet self version`
+
+Print the current version
+
+**Usage:** `ricochet self version`
 
 
 

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -20,7 +20,6 @@ This document contains the help content for the `ricochet` command-line program.
 * [`ricochet servers set-default`↴](#ricochet-servers-set-default)
 * [`ricochet self`↴](#ricochet-self)
 * [`ricochet self update`↴](#ricochet-self-update)
-* [`ricochet self version`↴](#ricochet-self-version)
 
 ## `ricochet`
 
@@ -244,7 +243,6 @@ Manage the ricochet CLI itself
 ###### **Subcommands:**
 
 * `update` — Update the ricochet CLI to the latest version
-* `version` — Print the current version
 
 
 
@@ -257,14 +255,6 @@ Update the ricochet CLI to the latest version
 ###### **Options:**
 
 * `-f`, `--force` — Force reinstall even if already on the latest version
-
-
-
-## `ricochet self version`
-
-Print the current version
-
-**Usage:** `ricochet self version`
 
 
 

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -138,7 +138,14 @@ pub async fn deploy(
     pb.enable_steady_tick(std::time::Duration::from_millis(80));
 
     match client
-        .deploy(&path, content_id.clone(), &toml_path, &extra_root_files, &pb, debug)
+        .deploy(
+            &path,
+            content_id.clone(),
+            &toml_path,
+            &extra_root_files,
+            &pb,
+            debug,
+        )
         .await
     {
         Ok(response) => {

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -91,6 +91,19 @@ fn binary_name_in_tarball(version: &str) -> Result<String> {
     }
 }
 
+pub fn print_version() {
+    let version = env!("CARGO_PKG_VERSION");
+    let git_hash = env!("GIT_HASH");
+    let has_tag = env!("HAS_GIT_TAG");
+    let build_date = env!("BUILD_DATE");
+
+    if has_tag == "true" || git_hash.is_empty() {
+        println!("{}", version);
+    } else {
+        println!("{}-{} ({})", version, git_hash, build_date);
+    }
+}
+
 pub async fn self_update(force: bool) -> Result<()> {
     println!("Checking for updates...");
 
@@ -231,8 +244,8 @@ fn extract_binary_from_tarball(tarball: &[u8], binary_path: &str) -> Result<Vec<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use flate2::write::GzEncoder;
     use flate2::Compression;
+    use flate2::write::GzEncoder;
     use std::io::Write;
 
     /// Create a tar.gz in memory with the given entries: (path, content).
@@ -245,9 +258,7 @@ mod tests {
                 header.set_size(content.len() as u64);
                 header.set_mode(0o755);
                 header.set_cksum();
-                builder
-                    .append_data(&mut header, *path, *content)
-                    .unwrap();
+                builder.append_data(&mut header, *path, *content).unwrap();
             }
             builder.finish().unwrap();
         }
@@ -264,8 +275,7 @@ mod tests {
         let content = b"fake-binary-content";
         let tarball = make_tarball(&[("ricochet-0.5.0-linux-x86_64", content)]);
 
-        let result =
-            extract_binary_from_tarball(&tarball, "ricochet-0.5.0-linux-x86_64").unwrap();
+        let result = extract_binary_from_tarball(&tarball, "ricochet-0.5.0-linux-x86_64").unwrap();
         assert_eq!(result, content);
     }
 
@@ -302,8 +312,7 @@ mod tests {
             ("other-file", b"nope"),
         ]);
 
-        let result =
-            extract_binary_from_tarball(&tarball, "ricochet-0.5.0-linux-x86_64").unwrap();
+        let result = extract_binary_from_tarball(&tarball, "ricochet-0.5.0-linux-x86_64").unwrap();
         assert_eq!(result, content);
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -100,8 +100,7 @@ impl Config {
             && legacy_path.exists()
         {
             if let Some(parent) = config_path.parent() {
-                std::fs::create_dir_all(parent)
-                    .context("Failed to create config directory")?;
+                std::fs::create_dir_all(parent).context("Failed to create config directory")?;
             }
             std::fs::rename(&legacy_path, &config_path).with_context(|| {
                 format!(
@@ -114,10 +113,7 @@ impl Config {
             if let Some(old_dir) = legacy_path.parent() {
                 let _ = std::fs::remove_dir(old_dir);
             }
-            eprintln!(
-                "Migrated config to {}",
-                config_path.display()
-            );
+            eprintln!("Migrated config to {}", config_path.display());
         }
 
         if config_path.exists() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -631,8 +631,6 @@ mod tests {
         );
     }
 
-    // ==================== resolve_server tests ====================
-
     #[test]
     fn test_resolve_server_by_name() {
         cleanup_env();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+use colored::Colorize;
 use ricochet_cli::{OutputFormat, commands, config::Config, update};
 
 #[derive(Parser)]
@@ -112,10 +113,17 @@ enum Commands {
         command: ServersCommands,
     },
     /// Update the ricochet CLI to the latest version
+    #[command(hide = true)]
     SelfUpdate {
         /// Force reinstall even if already on the latest version
         #[arg(short = 'f', long)]
         force: bool,
+    },
+    /// Manage the ricochet CLI itself
+    #[command(name = "self")]
+    Self_ {
+        #[command(subcommand)]
+        command: SelfCommands,
     },
     /// Generate markdown documentation (hidden command)
     #[command(hide = true)]
@@ -151,24 +159,25 @@ enum ServersCommands {
     },
 }
 
+#[derive(Subcommand)]
+enum SelfCommands {
+    /// Update the ricochet CLI to the latest version
+    Update {
+        /// Force reinstall even if already on the latest version
+        #[arg(short = 'f', long)]
+        force: bool,
+    },
+    /// Print the current version
+    Version,
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     // Handle version flag
     if cli.version {
-        let version = env!("CARGO_PKG_VERSION");
-        let git_hash = env!("GIT_HASH");
-        let has_tag = env!("HAS_GIT_TAG");
-        let build_date = env!("BUILD_DATE");
-
-        if has_tag == "true" || git_hash.is_empty() {
-            // Tagged release
-            println!("{}", version);
-        } else {
-            // Untagged build
-            println!("{}-{} ({})", version, git_hash, build_date);
-        }
+        commands::update::print_version();
         return Ok(());
     }
 
@@ -244,8 +253,21 @@ async fn main() -> Result<()> {
             }
         },
         Some(Commands::SelfUpdate { force }) => {
+            eprintln!(
+                "{} `ricochet self-update` is deprecated. Use `ricochet self update` instead.",
+                "warning:".yellow().bold()
+            );
             commands::update::self_update(force).await?;
         }
+        Some(Commands::Self_ { command }) => match command {
+            SelfCommands::Update { force } => {
+                commands::update::self_update(force).await?;
+            }
+            SelfCommands::Version => {
+                commands::update::print_version();
+                return Ok(());
+            }
+        },
         Some(Commands::GenerateDocs) => {
             let markdown = clap_markdown::help_markdown::<Cli>();
             println!("{}", markdown);

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,8 +167,6 @@ enum SelfCommands {
         #[arg(short = 'f', long)]
         force: bool,
     },
-    /// Print the current version
-    Version,
 }
 
 #[tokio::main]
@@ -262,10 +260,6 @@ async fn main() -> Result<()> {
         Some(Commands::Self_ { command }) => match command {
             SelfCommands::Update { force } => {
                 commands::update::self_update(force).await?;
-            }
-            SelfCommands::Version => {
-                commands::update::print_version();
-                return Ok(());
             }
         },
         Some(Commands::GenerateDocs) => {

--- a/src/update.rs
+++ b/src/update.rs
@@ -119,7 +119,7 @@ impl UpdateCache {
                 "notice:".yellow().bold(),
                 CURRENT_VERSION.dimmed(),
                 self.latest_version.green().bold(),
-                "ricochet self-update".bright_cyan(),
+                "ricochet self update".bright_cyan(),
                 release_notes_url(&self.latest_version).dimmed(),
             );
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -118,7 +118,12 @@ pub fn create_bundle(
         }
         for (source, name) in extra_root_files {
             if let Ok(metadata) = std::fs::metadata(source) {
-                println!("  {} (from {}) - {}", name, source.display(), format_size(metadata.len()));
+                println!(
+                    "  {} (from {}) - {}",
+                    name,
+                    source.display(),
+                    format_size(metadata.len())
+                );
             }
         }
         println!();
@@ -148,10 +153,7 @@ pub fn create_bundle(
     // Add extra files at the bundle root (e.g. uv.lock from a parent directory)
     for (source, name) in extra_root_files {
         tar.append_path_with_name(source, name)
-            .context(format!(
-                "Failed to add {} to bundle",
-                source.display()
-            ))?;
+            .context(format!("Failed to add {} to bundle", source.display()))?;
     }
 
     tar.finish().context("Failed to finalize tar bundle")?;

--- a/tests/servers_test.rs
+++ b/tests/servers_test.rs
@@ -294,6 +294,7 @@ mod servers_tests {
     // ==================== Config resolve_server tests ====================
 
     #[test]
+    #[serial(env_tests)]
     fn test_resolve_server_by_name() {
         cleanup_env();
         let _temp_dir = setup_test_env();
@@ -309,6 +310,7 @@ mod servers_tests {
     }
 
     #[test]
+    #[serial(env_tests)]
     fn test_resolve_server_by_url() {
         cleanup_env();
         let _temp_dir = setup_test_env();
@@ -345,6 +347,7 @@ mod servers_tests {
     }
 
     #[test]
+    #[serial(env_tests)]
     fn test_resolve_server_uses_default() {
         cleanup_env();
         let _temp_dir = setup_test_env();


### PR DESCRIPTION
This PR closes https://github.com/ricochet-rs/cli/issues/124

Renames `self-update` to `self update` to be consistent with other tools that provide a similar behavior. 

This is non-breaking.

New behavior:
```
cli ⚡ ricochet self-update
warning: `ricochet self-update` is deprecated. Use `ricochet self update` instead.
Checking for updates...
ri✓ Already on the latest version: 0.6.1
cli ⚡ ricochet self update
Checking for updates...
✓ Already on the latest version: 0.6.1
```