### PR TITLE
feat: add `ricochet db doctor` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2178,8 +2178,8 @@ dependencies = [
 
 [[package]]
 name = "ricochet-core"
-version = "0.7.1"
-source = "git+https://github.com/ricochet-rs/ricochet#bbde41bd31dc613b706cff4b5f0100a32f9eb33c"
+version = "0.7.0"
+source = "git+https://github.com/ricochet-rs/ricochet?branch=t3code%2F45df5d45#93d848378ec61149831a3f26d90981fbd5a3622f"
 dependencies = [
  "anyhow",
  "bytesize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ reqwest = { version = "0.13", default-features = false, features = [
   "rustls",
   "stream"
 ] }
-ricochet-core = { git = "https://github.com/ricochet-rs/ricochet", default-features = false }
+ricochet-core = { git = "https://github.com/ricochet-rs/ricochet", branch = "t3code/45df5d45", default-features = false }
 self-replace = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -23,6 +23,8 @@ This document contains the help content for the `ricochet` command-line program.
 * [`ricochet servers add`↴](#ricochet-servers-add)
 * [`ricochet servers remove`↴](#ricochet-servers-remove)
 * [`ricochet servers set-default`↴](#ricochet-servers-set-default)
+* [`ricochet db`↴](#ricochet-db)
+* [`ricochet db doctor`↴](#ricochet-db-doctor)
 * [`ricochet self`↴](#ricochet-self)
 * [`ricochet self update`↴](#ricochet-self-update)
 
@@ -44,6 +46,7 @@ Ricochet CLI
 * `app` — Manage deployed app items
 * `task` — Manage deployed task items
 * `servers` — Manage configured Ricochet servers
+* `db` — Database administration commands
 * `self` — Manage the ricochet CLI itself
 
 ###### **Options:**
@@ -308,6 +311,26 @@ Set the default server
 ###### **Arguments:**
 
 * `<NAME>` — Server name to set as default
+
+
+
+## `ricochet db`
+
+Database administration commands
+
+**Usage:** `ricochet db <COMMAND>`
+
+###### **Subcommands:**
+
+* `doctor` — Compare the server's live database schema against the build-time expected schema and report any drift. Requires an admin API key
+
+
+
+## `ricochet db doctor`
+
+Compare the server's live database schema against the build-time expected schema and report any drift. Requires an admin API key
+
+**Usage:** `ricochet db doctor`
 
 
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,8 +2,8 @@ use crate::config::{ServerConfig, parse_server_url};
 use anyhow::{Context, Result};
 use colored::Colorize;
 use reqwest::{Client, Response, StatusCode};
-use ricochet_core::content::ContentItem;
-use serde::de::DeserializeOwned;
+use ricochet_core::{content::ContentItem, drift::DriftReport};
+use serde::{Deserialize, de::DeserializeOwned};
 use serde_json::json;
 use std::{
     fs::read_to_string,
@@ -43,6 +43,14 @@ pub struct RicochetClient {
     pub(crate) client: Client,
     pub(crate) base_url: Url,
     pub(crate) api_key: String,
+}
+
+/// Shape of `GET /api/admin/db/doctor`. `healthy == true` means `drift` is
+/// empty; both fields are always populated.
+#[derive(Debug, Deserialize)]
+pub struct DoctorResponse {
+    pub healthy: bool,
+    pub drift: DriftReport,
 }
 
 impl RicochetClient {
@@ -403,6 +411,25 @@ impl RicochetClient {
         }
 
         Ok(())
+    }
+
+    /// Response body from `GET /api/admin/db/doctor`. Mirrors the
+    /// `DoctorResponse` defined server-side in
+    /// `ricochet-api/src/admin/db_doctor.rs`. Kept inline here because it's a
+    /// thin wire-format wrapper around the shared `DriftReport`; the CLI
+    /// never produces values of this type, only deserializes them.
+    pub async fn db_doctor(&self) -> Result<DoctorResponse> {
+        let mut url = self.base_url.clone();
+        url.set_path("/api/admin/db/doctor");
+
+        let response = self
+            .client
+            .get(url)
+            .header("Authorization", format!("Key {}", self.api_key))
+            .send()
+            .await?;
+
+        Self::handle_response(response).await
     }
 
     pub async fn get_ricochet_toml(&self, id: &str) -> Result<String> {

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -1,0 +1,226 @@
+//! `ricochet db doctor` — pull a database schema drift report from a
+//! Ricochet server and render it.
+//!
+//! The endpoint (`GET /api/admin/db/doctor`) requires an admin API key. The
+//! server compares its live schema against the build-time snapshot baked
+//! into the binary and returns a [`DoctorResponse`]. Empty drift means the
+//! database matches the migrations the server was built from.
+//!
+//! The handler defers to `OutputFormat`:
+//!
+//! * `Json` / `Yaml` — pass the raw response through `serde_*::to_string_pretty`
+//!   so other tooling can pipe it.
+//! * `Table` — print a human-readable summary: a healthy banner, or sectioned
+//!   tables for phantom tables, missing tables, and per-table shape drift.
+
+use crate::{
+    OutputFormat,
+    client::{DoctorResponse, RicochetClient},
+    config::Config,
+};
+use anyhow::Result;
+use colored::Colorize;
+use comfy_table::{Cell, Color, Table, presets::UTF8_FULL};
+use ricochet_core::drift::{ColumnDrift, DriftReport, ForeignKeyDrift, IndexDrift, TableDrift};
+
+pub async fn doctor(config: &Config, server_ref: Option<&str>, format: OutputFormat) -> Result<()> {
+    let server_config = config.resolve_server(server_ref)?;
+    let client = RicochetClient::new(&server_config)?;
+
+    let response = client.db_doctor().await?;
+
+    match format {
+        OutputFormat::Json => {
+            // Re-serialize so output mirrors the wire format byte-for-byte.
+            let value = serde_json::json!({
+                "healthy": response.healthy,
+                "drift": response.drift,
+            });
+            println!("{}", serde_json::to_string_pretty(&value)?);
+        }
+        OutputFormat::Yaml => {
+            let value = serde_json::json!({
+                "healthy": response.healthy,
+                "drift": response.drift,
+            });
+            println!("{}", serde_yaml::to_string(&value)?);
+        }
+        OutputFormat::Table => print_table(server_config.url.as_ref(), &response),
+    }
+
+    Ok(())
+}
+
+fn print_table(server_url: &str, response: &DoctorResponse) {
+    println!("{}", server_url.italic().dimmed());
+
+    if response.healthy {
+        println!(
+            "{} Database schema matches the expected schema for this server build.",
+            "✓".green().bold()
+        );
+        return;
+    }
+
+    println!("{} Database schema drift detected.", "✗".red().bold());
+
+    let drift = &response.drift;
+
+    if !drift.phantom_tables.is_empty() {
+        print_name_section(
+            "Phantom tables (in database, not in expected schema)",
+            &drift.phantom_tables,
+            Color::Red,
+        );
+    }
+
+    if !drift.missing_tables.is_empty() {
+        print_name_section(
+            "Missing tables (in expected schema, not in database)",
+            &drift.missing_tables,
+            Color::Yellow,
+        );
+    }
+
+    if !drift.table_drift.is_empty() {
+        print_table_drift(&drift.table_drift);
+    }
+
+    print_summary(drift);
+}
+
+fn print_name_section(title: &str, names: &[String], color: Color) {
+    println!("\n{}", title.bold());
+    let mut table = Table::new();
+    table.load_preset(UTF8_FULL);
+    table.set_header(vec!["Name"]);
+    for name in names {
+        table.add_row(vec![Cell::new(name).fg(color)]);
+    }
+    println!("{table}");
+}
+
+fn print_table_drift(table_drift: &std::collections::BTreeMap<String, TableDrift>) {
+    println!("\n{}", "Table shape drift".bold());
+
+    for (table_name, drift) in table_drift {
+        println!("\n  {}", table_name.cyan().bold());
+
+        if !drift.columns.is_empty() {
+            print_column_drift(&drift.columns);
+        }
+        if !drift.foreign_keys.is_empty() {
+            print_fk_drift(&drift.foreign_keys);
+        }
+        if !drift.indexes.is_empty() {
+            print_index_drift(&drift.indexes);
+        }
+    }
+}
+
+fn print_column_drift(items: &[ColumnDrift]) {
+    let mut table = Table::new();
+    table.load_preset(UTF8_FULL);
+    table.set_header(vec!["Column", "Drift", "Detail"]);
+    for item in items {
+        let (name, kind, detail) = match item {
+            ColumnDrift::Missing(n) => (n.clone(), "missing", String::new()),
+            ColumnDrift::Phantom(n) => (n.clone(), "phantom", String::new()),
+            ColumnDrift::Mismatch {
+                name,
+                expected,
+                actual,
+            } => {
+                let detail = format!(
+                    "expected: {} (not_null={}, pk={}, default={:?})  vs  actual: {} (not_null={}, pk={}, default={:?})",
+                    expected.sql_type,
+                    expected.not_null,
+                    expected.primary_key,
+                    expected.default_value,
+                    actual.sql_type,
+                    actual.not_null,
+                    actual.primary_key,
+                    actual.default_value,
+                );
+                (name.clone(), "mismatch", detail)
+            }
+        };
+        table.add_row(vec![
+            Cell::new(name),
+            Cell::new(kind).fg(color_for_kind(kind)),
+            Cell::new(detail),
+        ]);
+    }
+    println!("{table}");
+}
+
+fn print_fk_drift(items: &[ForeignKeyDrift]) {
+    let mut table = Table::new();
+    table.load_preset(UTF8_FULL);
+    table.set_header(vec!["Foreign key", "Drift"]);
+    for item in items {
+        let (label, kind) = match item {
+            ForeignKeyDrift::Missing(fk) => (
+                format!("{} -> {}.{}", fk.from_column, fk.to_table, fk.to_column),
+                "missing",
+            ),
+            ForeignKeyDrift::Phantom(fk) => (
+                format!("{} -> {}.{}", fk.from_column, fk.to_table, fk.to_column),
+                "phantom",
+            ),
+        };
+        table.add_row(vec![
+            Cell::new(label),
+            Cell::new(kind).fg(color_for_kind(kind)),
+        ]);
+    }
+    println!("{table}");
+}
+
+fn print_index_drift(items: &[IndexDrift]) {
+    let mut table = Table::new();
+    table.load_preset(UTF8_FULL);
+    table.set_header(vec!["Index", "Drift", "Detail"]);
+    for item in items {
+        let (name, kind, detail) = match item {
+            IndexDrift::Missing(n) => (n.clone(), "missing", String::new()),
+            IndexDrift::Phantom(n) => (n.clone(), "phantom", String::new()),
+            IndexDrift::Mismatch {
+                name,
+                expected,
+                actual,
+            } => {
+                let detail = format!(
+                    "expected: columns={:?} unique={}  vs  actual: columns={:?} unique={}",
+                    expected.columns, expected.unique, actual.columns, actual.unique,
+                );
+                (name.clone(), "mismatch", detail)
+            }
+        };
+        table.add_row(vec![
+            Cell::new(name),
+            Cell::new(kind).fg(color_for_kind(kind)),
+            Cell::new(detail),
+        ]);
+    }
+    println!("{table}");
+}
+
+fn color_for_kind(kind: &str) -> Color {
+    match kind {
+        "phantom" => Color::Red,
+        "missing" => Color::Yellow,
+        "mismatch" => Color::Magenta,
+        _ => Color::Reset,
+    }
+}
+
+fn print_summary(drift: &DriftReport) {
+    println!(
+        "\n{} {} phantom table(s), {} missing table(s), {} table(s) with shape drift",
+        "Summary:".bold(),
+        drift.phantom_tables.len(),
+        drift.missing_tables.len(),
+        drift.table_drift.len(),
+    );
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod config;
+pub mod db;
 pub mod delete;
 pub mod deploy;
 pub mod init;

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,6 +127,11 @@ enum Commands {
         #[command(subcommand)]
         command: ServersCommands,
     },
+    /// Database administration commands
+    Db {
+        #[command(subcommand)]
+        command: DbCommands,
+    },
     /// Update the ricochet CLI to the latest version
     #[command(hide = true)]
     SelfUpdate {
@@ -218,6 +223,13 @@ enum SelfCommands {
         #[arg(short = 'f', long)]
         force: bool,
     },
+}
+
+#[derive(Subcommand)]
+enum DbCommands {
+    /// Compare the server's live database schema against the build-time
+    /// expected schema and report any drift. Requires an admin API key.
+    Doctor,
 }
 
 #[tokio::main]
@@ -327,6 +339,11 @@ async fn main() -> Result<()> {
             }
             ServersCommands::SetDefault { name } => {
                 commands::servers::set_default(&mut config, name)?;
+            }
+        },
+        Some(Commands::Db { command }) => match command {
+            DbCommands::Doctor => {
+                commands::db::doctor(&config, cli.server.as_deref(), cli.format).await?;
             }
         },
         Some(Commands::SelfUpdate { force }) => {


### PR DESCRIPTION
## Summary

Adds a new `ricochet db doctor` CLI subcommand that pulls the database schema drift report from `GET /api/admin/db/doctor` and renders it according to the global `--format` flag:

- **table** (default) — sectioned summary with `comfy-table`: phantom tables, missing tables, per-table column/FK/index drift.
- **json** — `serde_json::to_string_pretty`.
- **yaml** — `serde_yaml::to_string`.

The endpoint requires an admin API key, enforced server-side. The shared wire types (`DriftReport`, `ExpectedColumn`, `ExpectedForeignKey`, …) come from `ricochet_core::{drift, schema}`, introduced in the corresponding `ricochet` PR.

## ⚠️ Blocker — do not merge before ricochet#906

`Cargo.toml` temporarily pins `ricochet-core` to `branch = "t3code/45df5d45"` so this branch can build before [ricochet#906](https://github.com/ricochet-rs/ricochet/pull/906) merges. That PR introduces:

1. The admin doctor endpoint (`GET /api/admin/db/doctor`).
2. API-key auth on that endpoint.
3. The shared `ricochet_core::drift` / `ricochet_core::schema` modules this PR consumes.

Once #906 is merged to `ricochet`'s `main`, the pin needs to be removed (one-line follow-up commit) so this CLI tracks the default branch again. Marking this PR as draft until that's done.

## Files

- `Cargo.toml` — temporary `ricochet-core` branch pin.
- `src/client.rs` — `RicochetClient::db_doctor()` + `DoctorResponse` wire-format wrapper.
- `src/commands/db.rs` (new) — handler with three render paths.
- `src/commands/mod.rs` — register the new module.
- `src/main.rs` — `Db { Doctor }` clap subcommand and dispatch.

## Verification

- `cargo check`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` — clean.
- `cargo test` — all 23 existing tests pass; no new tests added (subcommand is mostly an HTTP + render shell, exercised end-to-end against a live server).
- `ricochet db --help` and `ricochet db doctor --help` render with the right description and inherit global `--server` / `--format` / `--debug` flags.