### PR TITLE
ci: move entire release sequence into CI on tag push

### DIFF
--- a/.crow/binaries.yaml
+++ b/.crow/binaries.yaml
@@ -6,26 +6,40 @@ labels:
   agent: thumper
 
 steps:
-  'Verify tag matches Cargo.toml':
-    image: reg.ricochet.rs/docker.io/library/alpine:3.23
+  bump:
+    image: reg.ricochet.rs/docker.io/library/rust:1.95-slim
     when:
       event: tag
     commands:
-      - apk add --no-cache -q grep sed
+      - apt-get update -q && apt-get install -y -q git sed
       - |
-        EXPECTED="${CI_COMMIT_TAG#v}"
-        ACTUAL=$(grep -m1 '^version = ' Cargo.toml | sed -E 's/version = "([^"]+)"/\1/')
-        if [ "$EXPECTED" != "$ACTUAL" ]; then
-          echo "error: tag is v$EXPECTED but Cargo.toml says $ACTUAL" >&2
-          echo "run 'just bump $EXPECTED' on main first, merge, then re-tag" >&2
-          exit 1
+        set -euxo pipefail
+        VERSION="${CI_COMMIT_TAG#v}"
+
+        # Idempotent: sed is a no-op if the file is already at $VERSION.
+        sed -i "s/^version = \"[^\"]*\"/version = \"$VERSION\"/" Cargo.toml
+        sed -i "s/\(RICOCHET_VERSION:-\)[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*/\1$VERSION/" install.sh
+        sed -i "s/\$Version = if (\$env:RICOCHET_VERSION) { \$env:RICOCHET_VERSION } else { \"[^\"]*\" }/\$Version = if (\$env:RICOCHET_VERSION) { \$env:RICOCHET_VERSION } else { \"$VERSION\" }/" install.ps1
+        cargo update -p ricochet-cli
+
+        git config user.name "ricochet-bot"
+        git config user.email "droid@ricochet.rs"
+        git add Cargo.toml Cargo.lock install.sh install.ps1
+        if git diff --cached --quiet; then
+          echo "==> Files already at v$VERSION; no bump commit needed"
+        else
+          git commit -m "chore: bump version to $VERSION"
+          # Move the tag locally so 'build' picks up the bump commit and
+          # 'Push bump and tag' has the right SHA to force-update on the remote.
+          git tag -d "$CI_COMMIT_TAG"
+          git tag "$CI_COMMIT_TAG" HEAD
+          echo "==> Created bump commit and moved $CI_COMMIT_TAG to it"
         fi
-        echo "==> tag matches Cargo.toml ($ACTUAL)"
 
   build:
     image: reg.ricochet.rs/docker.io/library/rust:1.95-slim
     depends_on:
-      - 'Verify tag matches Cargo.toml'
+      - bump
     environment:
       GITHUB_TOKEN:
         from_secret: ricochet_bot_token
@@ -74,6 +88,45 @@ steps:
         echo -e "All binaries processed in $outdir/"
         ls -la "$outdir/"
 
+  'Push bump and tag':
+    image: reg.ricochet.rs/docker.io/library/alpine:3.23
+    when:
+      event: tag
+    depends_on:
+      - build
+    environment:
+      SSH_KEY:
+        from_secret: ricochet-bot-ssh-key
+    commands:
+      - apk add --no-cache -q git openssh-client
+      - |
+        set -euxo pipefail
+        mkdir -p ~/.ssh
+        echo "$SSH_KEY" > ~/.ssh/id_ed25519
+        chmod 600 ~/.ssh/id_ed25519
+        ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts 2>/dev/null
+
+        git config user.name "ricochet-bot"
+        git config user.email "droid@ricochet.rs"
+        git remote add origin-push git@github.com:ricochet-rs/cli.git
+        git fetch origin-push main
+
+        # If 'bump' didn't create a commit, nothing to push.
+        if [ "$(git rev-parse HEAD)" = "$(git rev-parse origin-push/main)" ]; then
+          echo "==> No bump commit to push (Cargo.toml already at v${CI_COMMIT_TAG#v})"
+          exit 0
+        fi
+
+        # Rebase the bump commit onto latest main (handles a race where main
+        # advanced between the user's tag push and this step). Then push and
+        # force-update the tag to the rebased bump commit.
+        git rebase origin-push/main
+        git push origin-push HEAD:main
+        git tag -d "$CI_COMMIT_TAG"
+        git tag "$CI_COMMIT_TAG" HEAD
+        git push origin-push --force "$CI_COMMIT_TAG"
+        echo "==> Pushed bump commit to main and force-updated $CI_COMMIT_TAG"
+
   'Upload to S3':
     image: reg.ricochet.rs/docker.io/woodpeckerci/plugin-s3:1.5.3
     depends_on:
@@ -100,7 +153,7 @@ steps:
   changelog:
     image: reg.ricochet.rs/docker.io/thegeeklab/git-sv:2.1.0
     depends_on:
-      - build
+      - 'Push bump and tag'
     commands:
       - apk add --no-cache -q sed
       - git sv current-version
@@ -128,7 +181,7 @@ steps:
   'Trigger homebrew-tap update':
     image: reg.ricochet.rs/docker.io/library/alpine:3.23
     depends_on:
-      - changelog
+      - 'Push bump and tag'
     environment:
       GITHUB_TOKEN:
         from_secret: ricochet_bot_token

--- a/Justfile
+++ b/Justfile
@@ -324,23 +324,3 @@ docs-check:
         echo "✓ CLI documentation is up-to-date"; \
         rm -f /tmp/cli-commands-generated.md; \
     fi
-
-# Bump version across Cargo.toml, Cargo.lock, install.sh, install.ps1.
-# Open a PR with the result, merge, then tag: git tag vX.Y.Z && git push --tags.
-# The CI tag pipeline verifies Cargo.toml matches the tag before building.
-bump VERSION:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if ! [[ "{{VERSION}}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        echo "error: version must be X.Y.Z (got '{{VERSION}}')" >&2
-        exit 1
-    fi
-    sed -i.bak "s/^version = \"[^\"]*\"/version = \"{{VERSION}}\"/" Cargo.toml && rm Cargo.toml.bak
-    sed -i.bak "s/\(RICOCHET_VERSION:-\)[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*/\1{{VERSION}}/" install.sh && rm install.sh.bak
-    sed -i.bak "s/\$Version = if (\$env:RICOCHET_VERSION) { \$env:RICOCHET_VERSION } else { \"[^\"]*\" }/\$Version = if (\$env:RICOCHET_VERSION) { \$env:RICOCHET_VERSION } else { \"{{VERSION}}\" }/" install.ps1 && rm install.ps1.bak
-    cargo update -p ricochet-cli
-    echo ""
-    echo "==> bumped to {{VERSION}}"
-    echo "    review: git diff"
-    echo "    commit: git commit -am 'chore: bump version to {{VERSION}}'"
-    echo "    PR, merge, then: git tag v{{VERSION}} && git push --tags"


### PR DESCRIPTION
## Summary

Follow-up to #141. Inverts the trigger model from "manual `just bump` then `git sv tag`" to "`git sv tag` is the only manual step; CI does the bump, commit, tag-move, build and release inline."

## Why

`git sv tag` only creates and pushes a tag at the current `HEAD`. It never mutates source files, so without something else in the chain, the tagged commit's `Cargo.toml` is always one version behind. That stale `Cargo.toml` is what GitHub serves at `archive/refs/tags/vX.Y.Z.tar.gz`, so anything that builds from source — Homebrew, `cargo install --git`, `cargo install --path` from a fresh clone — produces a binary that self-reports the *previous* version. v0.7.0 hit this. (v0.6.1 didn't only because at that point the bump commit happened to already be on `main` when the tag was placed.)

The previous attempt to fix this on the *server* side (the old `Update version files` / `Push version updates` steps) committed the bump *after* the tag, which can't fix the tag's source archive — it could only ever fix `main` for the *next* release. And in v0.7.0's case it didn't even do that, silently.

## How

On `event: tag`:

1. **`bump`** — sed `Cargo.toml`, `install.sh`, `install.ps1`; `cargo update -p ricochet-cli`; commit `chore: bump version to X.Y.Z`; move the tag locally to the bump commit. Idempotent: if the files are already at the target version, no commit and no tag move.
2. **`build`** — depends on `bump`, so the workspace already has the bumped `Cargo.toml`. No more in-memory `sed` patch.
3. **`Push bump and tag`** — depends on `build`. Rebases the bump commit on `origin/main` (handles a race where main moved during the build), pushes to `main`, then force-updates the tag on the remote so the source archive is coherent.
4. **`Upload to S3`** — depends on `build`, runs in parallel with push.
5. **`changelog`**, **`Create release`**, **`Trigger homebrew-tap update`** — depend (transitively) on `Push bump and tag`, so the published tag is the moved one.

## User flow now

```
# make commits...
git sv tag           # creates and pushes the tag
                     # (CI does everything else)
```

After CI completes, `git fetch --force --tags` to pick up the moved tag locally — the only papercut.

## Notes

- Removes the `just bump` recipe added in #141; the bump is no longer a manual step.
- Force-updating tags is required by this design. It's safe here because every release tag is owned by CI; humans only request the tag and don't otherwise rely on its initial commit pointer.
- `ricochet-bot` needs push access to `main` (bypassing branch protection) and the ability to force-update tags. Confirmed by repo owner.