### PR TITLE
ci: give the bump step the same GitHub auth as build

### DIFF
--- a/.crow/binaries.yaml
+++ b/.crow/binaries.yaml
@@ -10,8 +10,14 @@ steps:
     image: reg.ricochet.rs/docker.io/library/rust:1.95-slim
     when:
       event: tag
+    environment:
+      GITHUB_TOKEN:
+        from_secret: ricochet_bot_token
     commands:
       - apt-get update -q && apt-get install -y -q git sed
+      # cargo update -p ricochet-cli verifies the pinned ricochet-core git rev,
+      # which lives in a private repo — same auth shim as the build step.
+      - git config --global url."https://$GITHUB_TOKEN@github.com/".insteadOf "https://github.com/"
       - |
         set -euxo pipefail
         VERSION="${CI_COMMIT_TAG#v}"


### PR DESCRIPTION
The new \`bump\` step from #142 calls \`cargo update -p ricochet-cli\`, which re-verifies the git-pinned \`ricochet-core\` revision. That repo is private, so the fetch needs the same \`GITHUB_TOKEN\` + \`url.insteadOf\` shim that the build step has. Without it, the v0.7.1 release run failed with:

\`\`\`
fatal: could not read Username for 'https://github.com': No such device or address
...
unable to update https://github.com/ricochet-rs/ricochet#a3a31d09
\`\`\`

This adds the env var + git-config line to the bump step. Same secret, same shim, no other changes.