### PR TITLE
feat: add support for deployment endpoints

### DIFF
--- a/.crow/test.yaml
+++ b/.crow/test.yaml
@@ -12,20 +12,20 @@ steps:
   cache:
     image: codefloe.com/crow-plugins/sccache:0.2.4
     settings:
-      s3-endpoint: https://hel1.your-objectstorage.com
+      s3-endpoint: https://s3.eu-central-003.backblazeb2.com
       s3-bucket: ricochet-sccache
-      s3-region: hel1
+      s3-region: eu-central-003
       s3-key-prefix: ${CI_REPO_NAME}
       s3-access-key:
         from_secret:
           integration: 1
-          path: hetzner/s3/infrastructure
-          key: id
+          path: backblaze/tokens/cicd
+          key: keyID
       s3-secret-key:
         from_secret:
           integration: 1
-          path: hetzner/s3/infrastructure
-          key: secret
+          path: backblaze/tokens/cicd
+          key: applicationKey
 
   test:
     image: reg.ricochet.rs/docker.io/library/rust:1.95

--- a/.crow/test.yaml
+++ b/.crow/test.yaml
@@ -12,23 +12,24 @@ steps:
   cache:
     image: codefloe.com/crow-plugins/sccache:0.2.4
     settings:
-      s3-endpoint: https://s3.eu-central-003.backblazeb2.com
+      s3-endpoint: https://hel1.your-objectstorage.com
       s3-bucket: ricochet-sccache
-      s3-region: eu-central-003
+      s3-region: hel1
       s3-key-prefix: ${CI_REPO_NAME}
       s3-access-key:
         from_secret:
           integration: 1
-          path: backblaze/tokens/cicd
-          key: keyID
+          path: hetzner/s3/infrastructure
+          key: id
       s3-secret-key:
         from_secret:
           integration: 1
-          path: backblaze/tokens/cicd
-          key: applicationKey
+          path: hetzner/s3/infrastructure
+          key: secret
 
   test:
     image: reg.ricochet.rs/docker.io/library/rust:1.95
+    depends_on: cache
     environment:
       SQLX_OFFLINE: true
       GITHUB_TOKEN:

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -14,10 +14,16 @@ This document contains the help content for the `ricochet` command-line program.
 * [`ricochet init`↴](#ricochet-init)
 * [`ricochet app`↴](#ricochet-app)
 * [`ricochet app toml`↴](#ricochet-app-toml)
+* [`ricochet app deployment`↴](#ricochet-app-deployment)
+* [`ricochet app deployment list`↴](#ricochet-app-deployment-list)
+* [`ricochet app deployment get`↴](#ricochet-app-deployment-get)
 * [`ricochet task`↴](#ricochet-task)
 * [`ricochet task toml`↴](#ricochet-task-toml)
 * [`ricochet task invoke`↴](#ricochet-task-invoke)
 * [`ricochet task schedule`↴](#ricochet-task-schedule)
+* [`ricochet task deployment`↴](#ricochet-task-deployment)
+* [`ricochet task deployment list`↴](#ricochet-task-deployment-list)
+* [`ricochet task deployment get`↴](#ricochet-task-deployment-get)
 * [`ricochet servers`↴](#ricochet-servers)
 * [`ricochet servers list`↴](#ricochet-servers-list)
 * [`ricochet servers add`↴](#ricochet-servers-add)
@@ -169,6 +175,7 @@ Manage deployed app items
 ###### **Subcommands:**
 
 * `toml` — Fetch the remote _ricochet.toml for an item
+* `deployment` — Manage deployments for an app
 
 
 
@@ -188,6 +195,47 @@ Fetch the remote _ricochet.toml for an item
 
 
 
+## `ricochet app deployment`
+
+Manage deployments for an app
+
+**Usage:** `ricochet app deployment <COMMAND>`
+
+###### **Subcommands:**
+
+* `list` — List deployments for a content item
+* `get` — Get a specific deployment
+
+
+
+## `ricochet app deployment list`
+
+List deployments for a content item
+
+**Usage:** `ricochet app deployment list [OPTIONS] <ID>`
+
+###### **Arguments:**
+
+* `<ID>` — Content item ID (ULID)
+
+###### **Options:**
+
+* `--fields <FIELDS>` — Fields to display: 'all' or comma-separated names (id, status, deployed_at, deployed_by, content_id, requested_ver, matched_ver, git_hash)
+
+
+
+## `ricochet app deployment get`
+
+Get a specific deployment
+
+**Usage:** `ricochet app deployment get <ID>`
+
+###### **Arguments:**
+
+* `<ID>` — Deployment ID (ULID)
+
+
+
 ## `ricochet task`
 
 Manage deployed task items
@@ -199,6 +247,7 @@ Manage deployed task items
 * `toml` — Fetch the remote _ricochet.toml for a task
 * `invoke` — Invoke a task
 * `schedule` — Set or update the schedule for a task
+* `deployment` — Manage deployments for a task
 
 
 
@@ -240,6 +289,47 @@ Set or update the schedule for a task
 
 * `<ID>` — Content item ID (ULID)
 * `<SCHEDULE>` — Cron expression (e.g. "0 9 * * 1-5" for weekdays at 9am)
+
+
+
+## `ricochet task deployment`
+
+Manage deployments for a task
+
+**Usage:** `ricochet task deployment <COMMAND>`
+
+###### **Subcommands:**
+
+* `list` — List deployments for a content item
+* `get` — Get a specific deployment
+
+
+
+## `ricochet task deployment list`
+
+List deployments for a content item
+
+**Usage:** `ricochet task deployment list [OPTIONS] <ID>`
+
+###### **Arguments:**
+
+* `<ID>` — Content item ID (ULID)
+
+###### **Options:**
+
+* `--fields <FIELDS>` — Fields to display: 'all' or comma-separated names (id, status, deployed_at, deployed_by, content_id, requested_ver, matched_ver, git_hash)
+
+
+
+## `ricochet task deployment get`
+
+Get a specific deployment
+
+**Usage:** `ricochet task deployment get <ID>`
+
+###### **Arguments:**
+
+* `<ID>` — Deployment ID (ULID)
 
 
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -405,6 +405,36 @@ impl RicochetClient {
         Ok(())
     }
 
+    pub async fn list_deployments(
+        &self,
+        content_ulid: &str,
+    ) -> Result<Vec<crate::item::deployment::DeploymentRow>> {
+        let mut url = self.base_url.clone();
+        url.set_path(&format!("/api/v0/content/{}/deployments", content_ulid));
+        let response = self
+            .client
+            .get(url)
+            .header("Authorization", format!("Key {}", self.api_key))
+            .send()
+            .await?;
+        Self::handle_response(response).await
+    }
+
+    pub async fn get_deployment(
+        &self,
+        deployment_ulid: &str,
+    ) -> Result<crate::item::deployment::DeploymentRow> {
+        let mut url = self.base_url.clone();
+        url.set_path(&format!("/api/v0/content/deployments/{}", deployment_ulid));
+        let response = self
+            .client
+            .get(url)
+            .header("Authorization", format!("Key {}", self.api_key))
+            .send()
+            .await?;
+        Self::handle_response(response).await
+    }
+
     pub async fn get_ricochet_toml(&self, id: &str) -> Result<String> {
         let mut url = self.base_url.clone();
         url.set_path(&format!("/api/v0/content/{}/toml", id));

--- a/src/item/deployment.rs
+++ b/src/item/deployment.rs
@@ -1,0 +1,173 @@
+use crate::{OutputFormat, client::RicochetClient, config::Config};
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use colored::Colorize;
+use comfy_table::{Cell, Color, Table, presets::UTF8_FULL};
+use ricochet_core::events::DeploymentStatus;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeploymentRow {
+    pub id: String,
+    pub content_id: String,
+    pub deployed_at: i64,
+    pub status: DeploymentStatus,
+    pub deployed_by: String,
+    pub ip_address: String,
+    pub requested_ver: Option<String>,
+    pub matched_ver: Option<String>,
+    pub git_hash: Option<String>,
+}
+
+const DEFAULT_FIELDS: &[&str] = &["id", "status", "deployed_at"];
+
+const ALL_FIELDS: &[&str] = &[
+    "id",
+    "content_id",
+    "status",
+    "deployed_at",
+    "deployed_by",
+    "requested_ver",
+    "matched_ver",
+    "git_hash",
+];
+
+fn format_deployed_at(ts: i64) -> String {
+    DateTime::<Utc>::from_timestamp(ts, 0)
+        .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
+        .unwrap_or_else(|| ts.to_string())
+}
+
+fn status_cell(status: &DeploymentStatus) -> Cell {
+    let label = status.to_string();
+    match status {
+        DeploymentStatus::Success => Cell::new(label).fg(Color::Green),
+        DeploymentStatus::Failure | DeploymentStatus::Timeout => Cell::new(label).fg(Color::Red),
+        DeploymentStatus::Cancelled | DeploymentStatus::Invalidated => {
+            Cell::new(label).fg(Color::Yellow)
+        }
+        DeploymentStatus::Pending => Cell::new(label).fg(Color::Cyan),
+    }
+}
+
+fn resolve_fields(fields: Option<Vec<String>>) -> Vec<&'static str> {
+    match fields {
+        None => DEFAULT_FIELDS.to_vec(),
+        Some(f) if f.len() == 1 && f[0] == "all" => ALL_FIELDS.to_vec(),
+        Some(f) => ALL_FIELDS
+            .iter()
+            .copied()
+            .filter(|col| f.iter().any(|s| s == col))
+            .collect(),
+    }
+}
+
+fn field_header(field: &str) -> &'static str {
+    match field {
+        "id" => "ID",
+        "content_id" => "Content ID",
+        "status" => "Status",
+        "deployed_at" => "Deployed At",
+        "deployed_by" => "Deployed By",
+        "requested_ver" => "Requested Ver",
+        "matched_ver" => "Matched Ver",
+        "git_hash" => "Git Hash",
+        _ => "Unknown",
+    }
+}
+
+fn field_cell(field: &str, d: &DeploymentRow) -> Cell {
+    match field {
+        "id" => Cell::new(&d.id),
+        "content_id" => Cell::new(&d.content_id),
+        "status" => status_cell(&d.status),
+        "deployed_at" => Cell::new(format_deployed_at(d.deployed_at)),
+        "deployed_by" => Cell::new(&d.deployed_by),
+        "requested_ver" => Cell::new(d.requested_ver.as_deref().unwrap_or("-")),
+        "matched_ver" => Cell::new(d.matched_ver.as_deref().unwrap_or("-")),
+        "git_hash" => Cell::new(d.git_hash.as_deref().unwrap_or("-")),
+        _ => Cell::new("-"),
+    }
+}
+
+pub async fn list_deployments(
+    config: &Config,
+    server_ref: Option<&str>,
+    content_ulid: &str,
+    fields: Option<Vec<String>>,
+    format: OutputFormat,
+) -> Result<()> {
+    let server_config = config.resolve_server(server_ref)?;
+    let client = RicochetClient::new(&server_config)?;
+    client.preflight_key_check().await?;
+
+    let deployments = client.list_deployments(content_ulid).await?;
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&deployments)?);
+        }
+        OutputFormat::Yaml => {
+            println!("{}", serde_yaml::to_string(&deployments)?);
+        }
+        OutputFormat::Table => {
+            println!("{}", server_config.url.as_str().italic().dimmed());
+
+            if deployments.is_empty() {
+                println!("{}", "No deployments found.".yellow());
+                return Ok(());
+            }
+
+            let cols = resolve_fields(fields);
+
+            let mut table = Table::new();
+            table.load_preset(UTF8_FULL);
+            table.set_header(cols.iter().map(|c| field_header(c)));
+
+            for d in &deployments {
+                table.add_row(cols.iter().map(|c| field_cell(c, d)));
+            }
+
+            println!("{}", table);
+            println!("\n{} deployments", deployments.len());
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn get_deployment(
+    config: &Config,
+    server_ref: Option<&str>,
+    deployment_ulid: &str,
+    format: OutputFormat,
+) -> Result<()> {
+    let server_config = config.resolve_server(server_ref)?;
+    let client = RicochetClient::new(&server_config)?;
+    client.preflight_key_check().await?;
+
+    let d = client.get_deployment(deployment_ulid).await?;
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&d)?);
+        }
+        OutputFormat::Yaml => {
+            println!("{}", serde_yaml::to_string(&d)?);
+        }
+        OutputFormat::Table => {
+            println!("{}", server_config.url.as_str().italic().dimmed());
+
+            let mut table = Table::new();
+            table.load_preset(UTF8_FULL);
+
+            for col in ALL_FIELDS {
+                table.add_row(vec![Cell::new(field_header(col)), field_cell(col, &d)]);
+            }
+
+            println!("{}", table);
+        }
+    }
+
+    Ok(())
+}

--- a/src/item/mod.rs
+++ b/src/item/mod.rs
@@ -1,3 +1,4 @@
+pub mod deployment;
 pub mod invoke;
 pub mod schedule;
 pub mod toml;

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,6 +155,11 @@ enum ItemCommands {
         #[arg(short = 'p', long)]
         path: Option<std::path::PathBuf>,
     },
+    /// Manage deployments for an app
+    Deployment {
+        #[command(subcommand)]
+        command: DeploymentCommands,
+    },
 }
 
 #[derive(Subcommand)]
@@ -178,6 +183,29 @@ enum TaskCommands {
         id: String,
         /// Cron expression (e.g. "0 9 * * 1-5" for weekdays at 9am)
         schedule: String,
+    },
+    /// Manage deployments for a task
+    Deployment {
+        #[command(subcommand)]
+        command: DeploymentCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum DeploymentCommands {
+    /// List deployments for a content item
+    List {
+        /// Content item ID (ULID)
+        id: String,
+        /// Fields to display: 'all' or comma-separated names
+        /// (id, status, deployed_at, deployed_by, content_id, requested_ver, matched_ver, git_hash)
+        #[arg(long, value_delimiter = ',')]
+        fields: Option<Vec<String>>,
+    },
+    /// Get a specific deployment
+    Get {
+        /// Deployment ID (ULID)
+        id: String,
     },
 }
 
@@ -296,6 +324,27 @@ async fn main() -> Result<()> {
             ItemCommands::Toml { id, path } => {
                 item::toml::get_toml(&config, id, path).await?;
             }
+            ItemCommands::Deployment { command } => match command {
+                DeploymentCommands::List { id, fields } => {
+                    item::deployment::list_deployments(
+                        &config,
+                        cli.server.as_deref(),
+                        &id,
+                        fields,
+                        cli.format,
+                    )
+                    .await?;
+                }
+                DeploymentCommands::Get { id } => {
+                    item::deployment::get_deployment(
+                        &config,
+                        cli.server.as_deref(),
+                        &id,
+                        cli.format,
+                    )
+                    .await?;
+                }
+            },
         },
         Some(Commands::Task { command }) => match command {
             TaskCommands::Toml { id, path } => {
@@ -314,6 +363,27 @@ async fn main() -> Result<()> {
                 )
                 .await?;
             }
+            TaskCommands::Deployment { command } => match command {
+                DeploymentCommands::List { id, fields } => {
+                    item::deployment::list_deployments(
+                        &config,
+                        cli.server.as_deref(),
+                        &id,
+                        fields,
+                        cli.format,
+                    )
+                    .await?;
+                }
+                DeploymentCommands::Get { id } => {
+                    item::deployment::get_deployment(
+                        &config,
+                        cli.server.as_deref(),
+                        &id,
+                        cli.format,
+                    )
+                    .await?;
+                }
+            },
         },
         Some(Commands::Servers { command }) => match command {
             ServersCommands::List => {

--- a/tests/deployment_test.rs
+++ b/tests/deployment_test.rs
@@ -1,0 +1,234 @@
+use mockito::Server;
+use serde_json::json;
+use url::Url;
+
+#[cfg(test)]
+mod deployment_tests {
+    use super::*;
+
+    const CONTENT_ULID: &str = "01KQZMZXE17RV7TCNF3GGG24P4";
+    const DEPLOYMENT_ULID: &str = "01KQZPF4Y5SRHES967VZEYY765";
+
+    fn deployment_json() -> serde_json::Value {
+        json!({
+            "id": DEPLOYMENT_ULID,
+            "content_id": CONTENT_ULID,
+            "deployed_at": 1778106471,
+            "status": "success",
+            "deployed_by": "344509059241640593",
+            "ip_address": "127.0.0.1",
+            "requested_ver": "4.5.1",
+            "matched_ver": "4.5.2",
+            "git_hash": null
+        })
+    }
+
+    // --- list_deployments ---
+
+    #[tokio::test]
+    async fn test_list_deployments_success() {
+        let mut server = Server::new_async().await;
+
+        let _m = server
+            .mock(
+                "GET",
+                format!("/api/v0/content/{}/deployments", CONTENT_ULID).as_str(),
+            )
+            .match_header("authorization", "Key test_api_key")
+            .with_status(200)
+            .with_body(json!([deployment_json()]).to_string())
+            .create();
+
+        let config = ricochet_cli::config::Config::for_test(
+            Url::parse(&server.url()).unwrap(),
+            Some("test_api_key".to_string()),
+        );
+
+        let server_config = config.resolve_server(None).unwrap();
+        let client = ricochet_cli::client::RicochetClient::new(&server_config).unwrap();
+        let result = client.list_deployments(CONTENT_ULID).await;
+
+        assert!(result.is_ok());
+        let deployments = result.unwrap();
+        assert_eq!(deployments.len(), 1);
+        assert_eq!(deployments[0].id, DEPLOYMENT_ULID);
+        assert_eq!(deployments[0].content_id, CONTENT_ULID);
+    }
+
+    #[tokio::test]
+    async fn test_list_deployments_empty() {
+        let mut server = Server::new_async().await;
+
+        let _m = server
+            .mock(
+                "GET",
+                format!("/api/v0/content/{}/deployments", CONTENT_ULID).as_str(),
+            )
+            .match_header("authorization", "Key test_api_key")
+            .with_status(200)
+            .with_body(json!([]).to_string())
+            .create();
+
+        let config = ricochet_cli::config::Config::for_test(
+            Url::parse(&server.url()).unwrap(),
+            Some("test_api_key".to_string()),
+        );
+
+        let server_config = config.resolve_server(None).unwrap();
+        let client = ricochet_cli::client::RicochetClient::new(&server_config).unwrap();
+        let result = client.list_deployments(CONTENT_ULID).await;
+
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_list_deployments_unauthorized() {
+        let mut server = Server::new_async().await;
+
+        let _m = server
+            .mock(
+                "GET",
+                format!("/api/v0/content/{}/deployments", CONTENT_ULID).as_str(),
+            )
+            .match_header("authorization", "Key invalid_key")
+            .with_status(401)
+            .with_body(json!({"error": "Unauthorized"}).to_string())
+            .create();
+
+        let config = ricochet_cli::config::Config::for_test(
+            Url::parse(&server.url()).unwrap(),
+            Some("invalid_key".to_string()),
+        );
+
+        let server_config = config.resolve_server(None).unwrap();
+        let client = ricochet_cli::client::RicochetClient::new(&server_config).unwrap();
+        let result = client.list_deployments(CONTENT_ULID).await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_list_deployments_can_serialize_to_json() {
+        let mut server = Server::new_async().await;
+
+        let _m = server
+            .mock(
+                "GET",
+                format!("/api/v0/content/{}/deployments", CONTENT_ULID).as_str(),
+            )
+            .match_header("authorization", "Key test_api_key")
+            .with_status(200)
+            .with_body(json!([deployment_json()]).to_string())
+            .create();
+
+        let config = ricochet_cli::config::Config::for_test(
+            Url::parse(&server.url()).unwrap(),
+            Some("test_api_key".to_string()),
+        );
+
+        let server_config = config.resolve_server(None).unwrap();
+        let client = ricochet_cli::client::RicochetClient::new(&server_config).unwrap();
+        let result = client.list_deployments(CONTENT_ULID).await.unwrap();
+
+        let json_output = serde_json::to_string_pretty(&result);
+        assert!(json_output.is_ok());
+
+        let json_str = json_output.unwrap();
+        assert!(json_str.contains(DEPLOYMENT_ULID));
+        assert!(json_str.contains("success"));
+        assert!(json_str.contains("4.5.1"));
+    }
+
+    // --- get_deployment ---
+
+    #[tokio::test]
+    async fn test_get_deployment_success() {
+        let mut server = Server::new_async().await;
+
+        let _m = server
+            .mock(
+                "GET",
+                format!("/api/v0/content/deployments/{}", DEPLOYMENT_ULID).as_str(),
+            )
+            .match_header("authorization", "Key test_api_key")
+            .with_status(200)
+            .with_body(deployment_json().to_string())
+            .create();
+
+        let config = ricochet_cli::config::Config::for_test(
+            Url::parse(&server.url()).unwrap(),
+            Some("test_api_key".to_string()),
+        );
+
+        let server_config = config.resolve_server(None).unwrap();
+        let client = ricochet_cli::client::RicochetClient::new(&server_config).unwrap();
+        let result = client.get_deployment(DEPLOYMENT_ULID).await;
+
+        assert!(result.is_ok());
+        let d = result.unwrap();
+        assert_eq!(d.id, DEPLOYMENT_ULID);
+        assert_eq!(d.content_id, CONTENT_ULID);
+        assert_eq!(d.requested_ver.as_deref(), Some("4.5.1"));
+        assert_eq!(d.matched_ver.as_deref(), Some("4.5.2"));
+        assert!(d.git_hash.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_deployment_unauthorized() {
+        let mut server = Server::new_async().await;
+
+        let _m = server
+            .mock(
+                "GET",
+                format!("/api/v0/content/deployments/{}", DEPLOYMENT_ULID).as_str(),
+            )
+            .match_header("authorization", "Key invalid_key")
+            .with_status(401)
+            .with_body(json!({"error": "Unauthorized"}).to_string())
+            .create();
+
+        let config = ricochet_cli::config::Config::for_test(
+            Url::parse(&server.url()).unwrap(),
+            Some("invalid_key".to_string()),
+        );
+
+        let server_config = config.resolve_server(None).unwrap();
+        let client = ricochet_cli::client::RicochetClient::new(&server_config).unwrap();
+        let result = client.get_deployment(DEPLOYMENT_ULID).await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_deployment_can_serialize_to_json() {
+        let mut server = Server::new_async().await;
+
+        let _m = server
+            .mock(
+                "GET",
+                format!("/api/v0/content/deployments/{}", DEPLOYMENT_ULID).as_str(),
+            )
+            .match_header("authorization", "Key test_api_key")
+            .with_status(200)
+            .with_body(deployment_json().to_string())
+            .create();
+
+        let config = ricochet_cli::config::Config::for_test(
+            Url::parse(&server.url()).unwrap(),
+            Some("test_api_key".to_string()),
+        );
+
+        let server_config = config.resolve_server(None).unwrap();
+        let client = ricochet_cli::client::RicochetClient::new(&server_config).unwrap();
+        let result = client.get_deployment(DEPLOYMENT_ULID).await.unwrap();
+
+        let json_output = serde_json::to_string_pretty(&result);
+        assert!(json_output.is_ok());
+
+        let json_str = json_output.unwrap();
+        assert!(json_str.contains(DEPLOYMENT_ULID));
+        assert!(json_str.contains("success"));
+        assert!(json_str.contains("4.5.1"));
+    }
+}


### PR DESCRIPTION
This PR adds support for the ricochet API endpoints at `/api/v0/content/{ulid}/deployments` and `/api/v0/content/deployments/{ulid}`.

We will be able to use this to programmatically query the result of deployments in an integration test.