### PR TITLE
feat: deploy new item with existing content id via `--new` flag

### DIFF
--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -96,6 +96,7 @@ Deploy content to a Ricochet server
 
 * `-n`, `--name <NAME>` — Name for the deployment
 * `-d`, `--description <DESCRIPTION>` — Description for the deployment
+* `--new` — Force a new deployment, ignoring any existing content ID in _ricochet.toml
 
 
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -166,6 +166,7 @@ impl RicochetClient {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn deploy(
         &self,
         path: &Path,
@@ -173,6 +174,7 @@ impl RicochetClient {
         toml_path: &Path,
         extra_root_files: &[(std::path::PathBuf, String)],
         pb: &indicatif::ProgressBar,
+        new: bool,
         debug: bool,
     ) -> Result<serde_json::Value> {
         let mut url = self.base_url.clone();
@@ -222,7 +224,9 @@ impl RicochetClient {
                 .mime_str("application/x-tar")?,
         );
 
-        if let Some(id) = content_id {
+        if let Some(id) = content_id
+            && !new
+        {
             // Updating existing content
             form = form.text("id", id);
         } else {

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -12,6 +12,7 @@ pub async fn deploy(
     path: PathBuf,
     _name: Option<String>,
     _description: Option<String>,
+    new: bool,
     debug: bool,
 ) -> Result<()> {
     if !path.exists() {
@@ -144,6 +145,7 @@ pub async fn deploy(
             &toml_path,
             &extra_root_files,
             &pb,
+            new,
             debug,
         )
         .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,9 @@ enum Commands {
         /// Description for the deployment
         #[arg(short = 'd', long)]
         description: Option<String>,
+        /// Force a new deployment, ignoring any existing content ID in _ricochet.toml
+        #[arg(long)]
+        new: bool,
     },
     /// List all content items
     List {
@@ -245,6 +248,7 @@ async fn main() -> Result<()> {
             path,
             name,
             description,
+            new,
         }) => {
             commands::deploy::deploy(
                 &config,
@@ -252,6 +256,7 @@ async fn main() -> Result<()> {
                 path,
                 name,
                 description,
+                new,
                 cli.debug,
             )
             .await?;

--- a/tests/deploy_test.rs
+++ b/tests/deploy_test.rs
@@ -135,6 +135,7 @@ shinyApp(ui = ui, server = server)"#,
             None,
             None,
             false,
+            false,
         )
         .await;
 
@@ -192,6 +193,7 @@ shinyApp(ui = ui, server = server)"#,
             None,
             None,
             false,
+            false,
         )
         .await;
 
@@ -227,6 +229,7 @@ shinyApp(ui = ui, server = server)"#,
             project_path.to_path_buf(),
             None,
             None,
+            false,
             false,
         )
         .await;
@@ -273,6 +276,7 @@ key = "value"
             None,
             None,
             false,
+            false,
         )
         .await;
 
@@ -311,6 +315,7 @@ key = "value"
             project_path.to_path_buf(),
             None,
             None,
+            false,
             false,
         )
         .await;
@@ -369,6 +374,7 @@ key = "value"
             None,
             None,
             false,
+            false,
         )
         .await;
 
@@ -425,6 +431,7 @@ key = "value"
             None,
             None,
             false,
+            false,
         )
         .await;
 
@@ -475,6 +482,7 @@ key = "value"
             None,
             None,
             false,
+            false,
         )
         .await;
 
@@ -524,6 +532,7 @@ key = "value"
             project_path.to_path_buf(),
             None,
             None,
+            false,
             false,
         )
         .await;
@@ -576,6 +585,7 @@ key = "value"
             project_path.to_path_buf(),
             None,
             None,
+            false,
             false,
         )
         .await;
@@ -643,6 +653,7 @@ packages = "uv.lock"
             None,
             None,
             false,
+            false,
         )
         .await;
 
@@ -689,6 +700,7 @@ packages = "renv.lock"
             None,
             None,
             false,
+            false,
         )
         .await;
 
@@ -720,6 +732,7 @@ packages = "renv.lock"
             project_path.to_path_buf(),
             None,
             None,
+            false,
             false,
         )
         .await;
@@ -753,6 +766,7 @@ packages = "renv.lock"
             project_path.to_path_buf(),
             None,
             None,
+            false,
             false,
         )
         .await;
@@ -800,6 +814,7 @@ packages = "renv.lock"
             project_path.to_path_buf(),
             None,
             None,
+            false,
             false,
         )
         .await;
@@ -858,6 +873,7 @@ packages = "renv.lock"
             None,
             None,
             false,
+            false,
         )
         .await;
 
@@ -902,6 +918,7 @@ packages = "renv.lock"
             None,
             None,
             false,
+            false,
         )
         .await;
 
@@ -926,6 +943,7 @@ packages = "renv.lock"
             project_path.to_path_buf(),
             None,
             None,
+            false,
             false,
         )
         .await;


### PR DESCRIPTION
This PR adds a `--new` flag to the `ricochet deploy` command enabling users to deploy a content item with an existing `id` to a new server. 

This lets us have a single `_ricochet.toml` be used for multiple servers. 

Example of using the `--new` flag. Note that the `{content_id}` error fix is in a related PR in ricochet.
```
test-apps ⚡ ricochet deploy r/sleepy -S vm
📦 Creating new deployment for content item: 01KQZRGWY135NF0R4TJCJ1DXR3

Error: Deployment failed: Request failed with status 400 Bad Request: {"error":"Content item {content_id} cannot be found."}
test-apps ⚡ ricochet deploy r/sleepy -S vm --new
📦 Creating new deployment for content item: 01KQZRGWY135NF0R4TJCJ1DXR3

✓ Deployment successful!

Links:
  Deployment: https://dev.vm.ubuntu.ricochet.rs/deployments/01KR25T85FDA1C5BKKJ1EFAHB9
  App Overview: https://dev.vm.ubuntu.ricochet.rs/apps/01KQZRGWY135NF0R4TJCJ1DXR3/overview
```