### PR TITLE
refactor(deploy): always add config to the bundle

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -225,18 +225,16 @@ impl RicochetClient {
         if let Some(id) = content_id {
             // Updating existing content
             form = form.text("id", id);
-        } else {
-            // Creating new content - include the config file
-            let toml_file = tokio::fs::File::open(toml_path).await?;
-            let toml_body =
-                reqwest::Body::wrap_stream(tokio_util::io::ReaderStream::new(toml_file));
-            form = form.part(
-                "config",
-                reqwest::multipart::Part::stream(toml_body)
-                    .file_name("_ricochet.toml")
-                    .mime_str("application/toml")?,
-            );
         }
+        // always include the config file
+        let toml_file = tokio::fs::File::open(toml_path).await?;
+        let toml_body = reqwest::Body::wrap_stream(tokio_util::io::ReaderStream::new(toml_file));
+        form = form.part(
+            "config",
+            reqwest::multipart::Part::stream(toml_body)
+                .file_name("_ricochet.toml")
+                .mime_str("application/toml")?,
+        );
 
         let response = self
             .client

--- a/tests/deploy_test.rs
+++ b/tests/deploy_test.rs
@@ -401,6 +401,9 @@ key = "value"
             .match_body(Matcher::Regex(
                 r#"Content-Disposition: form-data; name="id""#.to_string(),
             ))
+            .match_body(Matcher::Regex(
+                r#"Content-Disposition: form-data; name="config""#.to_string(),
+            ))
             .with_status(200)
             .with_body(
                 json!({
@@ -427,6 +430,59 @@ key = "value"
             false,
         )
         .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_deploy_update_always_sends_config() {
+        // Regression: config field must be included even when updating existing content (content_id is set).
+        let temp_dir = TempDir::new().unwrap();
+        let project_path = temp_dir.path();
+        let existing_id = "01JZA237920RN65T2XHCCV7296";
+        create_test_project(project_path, Some(existing_id)).unwrap();
+
+        let mut server = Server::new_async().await;
+        let _ck = mock_check_key(&mut server);
+
+        // The mock requires the config part to be present; if it's absent mockito won't match
+        // and the request returns 501, causing the test to fail.
+        let _m = server
+            .mock("POST", "/api/v0/content/upload")
+            .match_header("authorization", "Key test_api_key")
+            .match_body(Matcher::Regex(
+                r#"Content-Disposition: form-data; name="config""#.to_string(),
+            ))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "id": existing_id,
+                    "name": "test-content",
+                    "content_type": "shiny",
+                    "status": "deployed"
+                })
+                .to_string(),
+            )
+            .create();
+
+        let config = ricochet_cli::config::Config::for_test(
+            Url::parse(&server.url()).unwrap(),
+            Some("test_api_key".to_string()),
+        );
+
+        let result = ricochet_cli::commands::deploy::deploy(
+            &config,
+            None,
+            project_path.to_path_buf(),
+            None,
+            None,
+            false,
+        )
+        .await;
+
+        if let Err(e) = &result {
+            dbg!(&e);
+        }
 
         assert!(result.is_ok());
     }


### PR DESCRIPTION
This PR takes advantage of https://github.com/ricochet-rs/ricochet/pull/1030 in which deploying an item with _ricochet.toml that already has an ID in it.

A side effect is that a single _ricochet.toml can be used for multiple servers.