### PR TITLE
feat: pass a default content ID for the `init` subcommand

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -485,7 +485,7 @@ pub fn init_rico_toml(
 
     let res = ContentItem {
         content: Content {
-            id: None,
+            id: Some(ulid::Ulid::new().to_string()),
             name,
             slug: None,
             entrypoint,


### PR DESCRIPTION
Closes #155 

Now that ricochet v0.10+ support deploying to a provided Ulid, there is no arm in instantiating a new ulid via `ricochet init`. This will prevent any issues having to deploy a new item, get the id from the cli, commit the new id, etc. 

