### PR TITLE
feat: add `--dry-run` to `self update`

### DIFF
--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -459,6 +459,7 @@ Update the ricochet CLI to the latest version
 ###### **Options:**
 
 * `-f`, `--force` — Force reinstall even if already on the latest version
+* `--dry-run` — Check for a newer version and report it without updating
 
 
 

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -104,7 +104,7 @@ pub fn print_version() {
     }
 }
 
-pub async fn self_update(force: bool) -> Result<()> {
+pub async fn self_update(force: bool, dry_run: bool) -> Result<()> {
     println!("Checking for updates...");
 
     let latest = update::fetch_latest_version()
@@ -112,6 +112,29 @@ pub async fn self_update(force: bool) -> Result<()> {
         .context("Failed to fetch latest version from GitHub")?;
 
     let latest_cache = update::UpdateCache::for_version(latest.clone());
+
+    if dry_run {
+        println!("  Current version: {}", CURRENT_VERSION.bright_cyan());
+        println!("  Latest version:  {}", latest.bright_cyan());
+
+        if latest_cache.is_update_available() {
+            println!(
+                "\n{} Update available: {} -> {}",
+                "→".green().bold(),
+                CURRENT_VERSION.dimmed(),
+                latest.green().bold()
+            );
+            println!(
+                "  Release notes: {}",
+                update::release_notes_url(&latest).bright_cyan()
+            );
+            println!("\nRun {} to update.", "ricochet self update".bright_cyan());
+        } else {
+            println!("\n{} Already on the latest version.", "✓".green().bold());
+        }
+
+        return Ok(());
+    }
 
     if !latest_cache.is_update_available() && !force {
         println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,9 @@ enum Commands {
         /// Force reinstall even if already on the latest version
         #[arg(short = 'f', long)]
         force: bool,
+        /// Check for a newer version and report it without updating
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Manage the ricochet CLI itself
     #[command(name = "self")]
@@ -263,6 +266,9 @@ enum SelfCommands {
         /// Force reinstall even if already on the latest version
         #[arg(short = 'f', long)]
         force: bool,
+        /// Check for a newer version and report it without updating
+        #[arg(long)]
+        dry_run: bool,
     },
 }
 
@@ -437,16 +443,16 @@ async fn main() -> Result<()> {
                 commands::servers::set_default(&mut config, name)?;
             }
         },
-        Some(Commands::SelfUpdate { force }) => {
+        Some(Commands::SelfUpdate { force, dry_run }) => {
             eprintln!(
                 "{} `ricochet self-update` is deprecated. Use `ricochet self update` instead.",
                 "warning:".yellow().bold()
             );
-            commands::update::self_update(force).await?;
+            commands::update::self_update(force, dry_run).await?;
         }
         Some(Commands::Self_ { command }) => match command {
-            SelfCommands::Update { force } => {
-                commands::update::self_update(force).await?;
+            SelfCommands::Update { force, dry_run } => {
+                commands::update::self_update(force, dry_run).await?;
             }
         },
         Some(Commands::GenerateDocs) => {


### PR DESCRIPTION
## Summary

Adds `ricochet self update --dry-run` (requested in #121). It checks for a newer release and reports the current and latest version without downloading or replacing the binary.

- New `--dry-run` flag on `self update` (and the deprecated `self-update` alias).
- Dry-run output prints current vs. latest version, whether an update is available, and a link to the release notes.
- Regenerated `docs/cli-commands.md`.

Example when up to date:

```
Checking for updates...
  Current version: 0.7.1
  Latest version:  0.7.1

✓ Already on the latest version.
```

When a newer version exists it prints `→ Update available: <current> -> <latest>`, the release-notes URL, and a hint to run `ricochet self update`.

Closes #121.