### PR TITLE
feat: update app/task settings from _ricochet.toml

### DIFF
--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -16,6 +16,8 @@ This document contains the help content for the `ricochet` command-line program.
 * [`ricochet app toml`↴](#ricochet-app-toml)
 * [`ricochet app list`↴](#ricochet-app-list)
 * [`ricochet app stop`↴](#ricochet-app-stop)
+* [`ricochet app settings`↴](#ricochet-app-settings)
+* [`ricochet app settings update`↴](#ricochet-app-settings-update)
 * [`ricochet app deployment`↴](#ricochet-app-deployment)
 * [`ricochet app deployment list`↴](#ricochet-app-deployment-list)
 * [`ricochet app deployment get`↴](#ricochet-app-deployment-get)
@@ -23,6 +25,8 @@ This document contains the help content for the `ricochet` command-line program.
 * [`ricochet task toml`↴](#ricochet-task-toml)
 * [`ricochet task invoke`↴](#ricochet-task-invoke)
 * [`ricochet task schedule`↴](#ricochet-task-schedule)
+* [`ricochet task settings`↴](#ricochet-task-settings)
+* [`ricochet task settings update`↴](#ricochet-task-settings-update)
 * [`ricochet task deployment`↴](#ricochet-task-deployment)
 * [`ricochet task deployment list`↴](#ricochet-task-deployment-list)
 * [`ricochet task deployment get`↴](#ricochet-task-deployment-get)
@@ -179,6 +183,7 @@ Manage deployed app items
 * `toml` — Fetch the remote _ricochet.toml for an item
 * `list` — List running instances
 * `stop` — Stop a running instance, or all instances if no instance ID is given
+* `settings` — Show the diff between the local _ricochet.toml and the deployed item. Use the `update` subcommand to apply it
 * `deployment` — Manage deployments for an app
 
 
@@ -229,6 +234,35 @@ Stop a running instance, or all instances if no instance ID is given
 ###### **Options:**
 
 * `-p`, `--path <PATH>` — Path to _ricochet.toml file
+
+
+
+## `ricochet app settings`
+
+Show the diff between the local _ricochet.toml and the deployed item. Use the `update` subcommand to apply it
+
+**Usage:** `ricochet app settings [OPTIONS] [COMMAND]`
+
+###### **Subcommands:**
+
+* `update` — Apply local _ricochet.toml settings to the server
+
+###### **Options:**
+
+* `-p`, `--path <PATH>` — Path to _ricochet.toml file
+
+
+
+## `ricochet app settings update`
+
+Apply local _ricochet.toml settings to the server
+
+**Usage:** `ricochet app settings update [OPTIONS]`
+
+###### **Options:**
+
+* `-p`, `--path <PATH>` — Path to _ricochet.toml file
+* `-f`, `--force` — Skip the confirmation prompt
 
 
 
@@ -284,6 +318,7 @@ Manage deployed task items
 * `toml` — Fetch the remote _ricochet.toml for a task
 * `invoke` — Invoke a task
 * `schedule` — Set or update the schedule for a task
+* `settings` — Show the diff between the local _ricochet.toml and the deployed item. Use the `update` subcommand to apply it
 * `deployment` — Manage deployments for a task
 
 
@@ -326,6 +361,35 @@ Set or update the schedule for a task
 
 * `<ID>` — Content item ID (ULID)
 * `<SCHEDULE>` — Cron expression (e.g. "0 9 * * 1-5" for weekdays at 9am)
+
+
+
+## `ricochet task settings`
+
+Show the diff between the local _ricochet.toml and the deployed item. Use the `update` subcommand to apply it
+
+**Usage:** `ricochet task settings [OPTIONS] [COMMAND]`
+
+###### **Subcommands:**
+
+* `update` — Apply local _ricochet.toml settings to the server
+
+###### **Options:**
+
+* `-p`, `--path <PATH>` — Path to _ricochet.toml file
+
+
+
+## `ricochet task settings update`
+
+Apply local _ricochet.toml settings to the server
+
+**Usage:** `ricochet task settings update [OPTIONS]`
+
+###### **Options:**
+
+* `-p`, `--path <PATH>` — Path to _ricochet.toml file
+* `-f`, `--force` — Skip the confirmation prompt
 
 
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -394,17 +394,15 @@ impl RicochetClient {
         Ok(())
     }
 
-    pub async fn update_settings(&self, id: &str, settings: &str) -> Result<()> {
+    pub async fn update_settings(&self, id: &str, settings: &serde_json::Value) -> Result<()> {
         let mut url = self.base_url.clone();
         url.set_path(&format!("/api/v0/content/{}/settings", id));
-
-        let body: serde_json::Value = serde_json::from_str(settings)?;
 
         let response = self
             .client
             .patch(url)
             .header("Authorization", format!("Key {}", self.api_key))
-            .json(&body)
+            .json(settings)
             .send()
             .await?;
 

--- a/src/item/mod.rs
+++ b/src/item/mod.rs
@@ -1,4 +1,5 @@
 pub mod deployment;
 pub mod invoke;
 pub mod schedule;
+pub mod settings;
 pub mod toml;

--- a/src/item/settings.rs
+++ b/src/item/settings.rs
@@ -1,0 +1,392 @@
+use anyhow::Result;
+use ricochet_core::content::ContentItem;
+use serde_json::{Map, Value, json};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FieldChange {
+    pub field: String,
+    pub from: String,
+    pub to: String,
+}
+
+fn opt_str(o: &Option<String>) -> Value {
+    match o {
+        Some(s) => Value::String(s.clone()),
+        None => Value::Null,
+    }
+}
+
+fn opt_path(o: &Option<std::path::PathBuf>) -> Value {
+    match o {
+        Some(p) => Value::String(p.to_string_lossy().into_owned()),
+        None => Value::Null,
+    }
+}
+
+fn render(v: &Value) -> String {
+    match v {
+        Value::Null => "(unset)".to_string(),
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+struct PatchBuilder {
+    changes: Vec<FieldChange>,
+    patch: Map<String, Value>,
+}
+
+impl PatchBuilder {
+    fn new() -> Self {
+        Self {
+            changes: Vec::new(),
+            patch: Map::new(),
+        }
+    }
+
+    /// Diff a single field within a group; always considered.
+    fn field(&mut self, group: &str, name: &str, remote: Value, local: Value) {
+        if remote != local {
+            self.changes.push(FieldChange {
+                field: format!("{group}.{name}"),
+                from: render(&remote),
+                to: render(&local),
+            });
+            self.patch
+                .entry(group.to_string())
+                .or_insert_with(|| Value::Object(Map::new()))
+                .as_object_mut()
+                .expect("group entry is always an object")
+                .insert(name.to_string(), local);
+        }
+    }
+
+    /// Diff a single optional field; skipped entirely when unset locally so we
+    /// never push a `null` the user did not ask for (the endpoint ignores nulls).
+    fn field_opt(&mut self, group: &str, name: &str, remote: Value, local: Value) {
+        if local.is_null() {
+            return;
+        }
+        self.field(group, name, remote, local);
+    }
+
+    /// Diff a whole group value (used for `packages`).
+    fn whole(&mut self, group: &str, remote: Value, local: Value) {
+        if remote != local {
+            self.changes.push(FieldChange {
+                field: group.to_string(),
+                from: "(changed)".to_string(),
+                to: "(changed)".to_string(),
+            });
+            self.patch.insert(group.to_string(), local);
+        }
+    }
+
+    fn finish(self) -> (Vec<FieldChange>, Value) {
+        (self.changes, Value::Object(self.patch))
+    }
+}
+
+/// Compute the patchable difference between the remote and local content items.
+/// Returns a human-readable change list and the JSON body for the settings PATCH.
+pub fn compute_patch(
+    remote: &ContentItem,
+    local: &ContentItem,
+) -> Result<(Vec<FieldChange>, Value)> {
+    let mut b = PatchBuilder::new();
+
+    // content — required scalars are always compared
+    b.field(
+        "content",
+        "name",
+        Value::String(remote.content.name.clone()),
+        Value::String(local.content.name.clone()),
+    );
+    b.field(
+        "content",
+        "entrypoint",
+        Value::String(remote.content.entrypoint.to_string_lossy().into_owned()),
+        Value::String(local.content.entrypoint.to_string_lossy().into_owned()),
+    );
+    b.field(
+        "content",
+        "access_type",
+        serde_json::to_value(&remote.content.access_type)?,
+        serde_json::to_value(&local.content.access_type)?,
+    );
+    b.field(
+        "content",
+        "content_type",
+        serde_json::to_value(&remote.content.content_type)?,
+        serde_json::to_value(&local.content.content_type)?,
+    );
+
+    // content — optional fields only when set locally
+    if local.content.slug.is_some() {
+        b.field(
+            "content",
+            "slug",
+            opt_str(&remote.content.slug),
+            opt_str(&local.content.slug),
+        );
+    }
+    if local.content.summary.is_some() {
+        b.field(
+            "content",
+            "summary",
+            opt_str(&remote.content.summary),
+            opt_str(&local.content.summary),
+        );
+    }
+    if local.content.thumbnail.is_some() {
+        b.field(
+            "content",
+            "thumbnail",
+            opt_path(&remote.content.thumbnail),
+            opt_path(&local.content.thumbnail),
+        );
+    }
+    if local.content.tags.is_some() {
+        b.field(
+            "content",
+            "tags",
+            serde_json::to_value(&remote.content.tags)?,
+            serde_json::to_value(&local.content.tags)?,
+        );
+    }
+    if local.content.exec_env.is_some() {
+        b.field(
+            "content",
+            "exec_env",
+            opt_str(&remote.content.exec_env),
+            opt_str(&local.content.exec_env),
+        );
+    }
+
+    // serve — only when the local TOML declares a [serve] block
+    if let Some(local_serve) = &local.serve {
+        let remote_serve = remote.serve.clone().unwrap_or_default();
+        b.field(
+            "serve",
+            "min_instances",
+            json!(remote_serve.min_instances),
+            json!(local_serve.min_instances),
+        );
+        b.field(
+            "serve",
+            "max_instances",
+            json!(remote_serve.max_instances),
+            json!(local_serve.max_instances),
+        );
+        b.field(
+            "serve",
+            "spawn_threshold",
+            json!(remote_serve.spawn_threshold),
+            json!(local_serve.spawn_threshold),
+        );
+        b.field(
+            "serve",
+            "max_connections",
+            json!(remote_serve.max_connections),
+            json!(local_serve.max_connections),
+        );
+        b.field_opt(
+            "serve",
+            "max_connection_age",
+            json!(remote_serve.max_connection_age),
+            json!(local_serve.max_connection_age),
+        );
+        b.field_opt(
+            "serve",
+            "inactive_timeout",
+            json!(remote_serve.inactive_timeout),
+            json!(local_serve.inactive_timeout),
+        );
+        b.field_opt(
+            "serve",
+            "connection_timeout",
+            json!(remote_serve.connection_timeout),
+            json!(local_serve.connection_timeout),
+        );
+
+        // deployment — maps to [serve.k8s]; only when declared locally
+        if let Some(local_k8s) = &local_serve.k8s {
+            let remote_k8s = remote_serve.k8s.clone().unwrap_or_default();
+            b.field(
+                "deployment",
+                "strategy",
+                serde_json::to_value(remote_k8s.strategy)?,
+                serde_json::to_value(local_k8s.strategy)?,
+            );
+            b.field_opt(
+                "deployment",
+                "max_surge",
+                opt_str(&remote_k8s.max_surge),
+                opt_str(&local_k8s.max_surge),
+            );
+            b.field_opt(
+                "deployment",
+                "max_unavailable",
+                opt_str(&remote_k8s.max_unavailable),
+                opt_str(&local_k8s.max_unavailable),
+            );
+            b.field_opt(
+                "deployment",
+                "config",
+                opt_str(&remote_k8s.config),
+                opt_str(&local_k8s.config),
+            );
+        }
+    }
+
+    // resources — only when declared locally
+    if let Some(local_res) = &local.resources {
+        let remote_res = remote.resources.clone().unwrap_or_default();
+        b.field_opt(
+            "resources",
+            "cpu_request",
+            opt_str(&remote_res.cpu_request),
+            opt_str(&local_res.cpu_request),
+        );
+        b.field_opt(
+            "resources",
+            "cpu_limit",
+            opt_str(&remote_res.cpu_limit),
+            opt_str(&local_res.cpu_limit),
+        );
+        b.field_opt(
+            "resources",
+            "memory_request",
+            opt_str(&remote_res.memory_request),
+            opt_str(&local_res.memory_request),
+        );
+        b.field_opt(
+            "resources",
+            "memory_limit",
+            opt_str(&remote_res.memory_limit),
+            opt_str(&local_res.memory_limit),
+        );
+    }
+
+    // static — only when declared locally
+    if let Some(local_static) = &local.static_ {
+        let remote_static = remote.static_.clone().unwrap_or_default();
+        b.field_opt(
+            "static",
+            "index",
+            opt_str(&remote_static.index),
+            opt_str(&local_static.index),
+        );
+        b.field_opt(
+            "static",
+            "output_dir",
+            opt_str(&remote_static.output_dir),
+            opt_str(&local_static.output_dir),
+        );
+    }
+
+    // packages — only when declared locally; sent as a whole value
+    if let Some(local_pkgs) = &local.repositories {
+        b.whole(
+            "packages",
+            serde_json::to_value(&remote.repositories)?,
+            serde_json::to_value(local_pkgs)?,
+        );
+    }
+
+    Ok(b.finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASE: &str = r#"
+[content]
+id = "01KE52BY41EQ7NE89K7Z5MMZ84"
+name = "example-app"
+entrypoint = "app.R"
+access_type = "private"
+content_type = "shiny"
+
+[language]
+name = "r"
+packages = "renv.lock"
+
+[serve]
+min_instances = 0
+max_instances = 5
+spawn_threshold = 80
+max_connections = 10
+"#;
+
+    const BASE_NO_SERVE: &str = r#"
+[content]
+id = "01KE52BY41EQ7NE89K7Z5MMZ84"
+name = "example-app"
+entrypoint = "app.R"
+access_type = "private"
+content_type = "shiny"
+
+[language]
+name = "r"
+packages = "renv.lock"
+"#;
+
+    fn parse(toml: &str) -> ContentItem {
+        ContentItem::from_toml(toml).unwrap()
+    }
+
+    #[test]
+    fn no_changes_when_identical() {
+        let item = parse(BASE);
+        let (changes, patch) = compute_patch(&item, &item).unwrap();
+        assert!(changes.is_empty());
+        assert_eq!(patch, json!({}));
+    }
+
+    #[test]
+    fn detects_serve_change() {
+        let remote = parse(BASE);
+        let local = parse(&BASE.replace("min_instances = 0", "min_instances = 2"));
+        let (changes, patch) = compute_patch(&remote, &local).unwrap();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].field, "serve.min_instances");
+        assert_eq!(patch, json!({"serve": {"min_instances": 2}}));
+    }
+
+    #[test]
+    fn detects_access_type_change() {
+        let remote = parse(BASE);
+        let local = parse(&BASE.replace("access_type = \"private\"", "access_type = \"external\""));
+        let (_changes, patch) = compute_patch(&remote, &local).unwrap();
+        assert_eq!(patch, json!({"content": {"access_type": "external"}}));
+    }
+
+    #[test]
+    fn absent_local_serve_is_not_reset() {
+        let remote = parse(BASE);
+        let local = parse(BASE_NO_SERVE);
+        let (changes, patch) = compute_patch(&remote, &local).unwrap();
+        assert!(patch.get("serve").is_none());
+        assert!(!changes.iter().any(|c| c.field.starts_with("serve")));
+    }
+
+    #[test]
+    fn detects_changes_across_sections() {
+        let remote = parse(BASE);
+        let modified = BASE
+            .replace("access_type = \"private\"", "access_type = \"external\"")
+            .replace("min_instances = 0", "min_instances = 3");
+        let local = parse(&modified);
+        let (changes, patch) = compute_patch(&remote, &local).unwrap();
+        assert_eq!(
+            patch,
+            json!({
+                "content": {"access_type": "external"},
+                "serve": {"min_instances": 3}
+            })
+        );
+        assert_eq!(changes.len(), 2);
+    }
+}

--- a/src/item/settings.rs
+++ b/src/item/settings.rs
@@ -177,8 +177,8 @@ pub fn compute_patch(
     b.field(
         "content",
         "content_type",
-        serde_json::to_value(&remote.content.content_type)?,
-        serde_json::to_value(&local.content.content_type)?,
+        serde_json::to_value(remote.content.content_type)?,
+        serde_json::to_value(local.content.content_type)?,
     );
 
     // content — optional fields only when set locally

--- a/src/item/settings.rs
+++ b/src/item/settings.rs
@@ -1,12 +1,72 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
+use colored::Colorize;
 use ricochet_core::content::ContentItem;
 use serde_json::{Map, Value, json};
+use std::{
+    fs::read_to_string,
+    path::{Path, PathBuf},
+};
+
+use crate::{OutputFormat, client::RicochetClient, config::Config, utils};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct FieldChange {
     pub field: String,
     pub from: String,
     pub to: String,
+}
+
+/// Load the local `_ricochet.toml`, returning its content ID and parsed item.
+fn load_local(path: Option<&Path>) -> Result<(String, ContentItem)> {
+    let toml_path = path
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("_ricochet.toml"));
+    if !toml_path.exists() {
+        anyhow::bail!(
+            "{} No `_ricochet.toml` found at {}. Provide one with --path.",
+            "⚠".yellow(),
+            toml_path.display()
+        );
+    }
+    let toml = read_to_string(&toml_path)?;
+    let item = ContentItem::from_toml(&toml).context("parsing local _ricochet.toml")?;
+    let Some(id) = item.content.id.clone() else {
+        anyhow::bail!("Local _ricochet.toml has no item ID. Deploy the item first.");
+    };
+    Ok((id, item))
+}
+
+/// Print the change list as a human-readable diff (remote → local).
+fn print_changes(id: &str, name: &str, changes: &[FieldChange]) {
+    println!(
+        "{} Local settings differ from {} ({})",
+        "⚠".yellow().bold(),
+        id.bright_cyan(),
+        name
+    );
+    println!();
+    let width = changes.iter().map(|c| c.field.len()).max().unwrap_or(0);
+    for c in changes {
+        println!(
+            "  {:<width$}  {} {} {}",
+            c.field,
+            c.from.dimmed(),
+            "→".dimmed(),
+            c.to,
+            width = width
+        );
+    }
+}
+
+/// Fetch the remote item and diff it against the local one.
+async fn diff_against_remote(
+    client: &RicochetClient,
+    id: &str,
+    local: &ContentItem,
+) -> Result<(Vec<FieldChange>, Value)> {
+    let remote_toml = client.get_ricochet_toml(id).await?;
+    let remote = ContentItem::from_toml(&remote_toml).context("parsing remote _ricochet.toml")?;
+    compute_patch(&remote, local)
 }
 
 fn opt_str(o: &Option<String>) -> Value {
@@ -295,6 +355,88 @@ pub fn compute_patch(
     }
 
     Ok(b.finish())
+}
+
+/// Show the diff between the local `_ricochet.toml` and the deployed item.
+pub async fn preview(
+    config: &Config,
+    server_ref: Option<&str>,
+    path: Option<&Path>,
+    format: OutputFormat,
+) -> Result<()> {
+    let (id, local) = load_local(path)?;
+    let server_config = config.resolve_server(server_ref)?;
+    let client = RicochetClient::new(&server_config)?;
+    client.preflight_key_check().await?;
+
+    let (changes, patch) = diff_against_remote(&client, &id, &local).await?;
+
+    match format {
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&patch)?),
+        OutputFormat::Yaml => println!("{}", serde_yaml::to_string(&patch)?),
+        OutputFormat::Table => {
+            if changes.is_empty() {
+                println!("{} Settings already up to date", "✓".green().bold());
+            } else {
+                print_changes(&id, &local.content.name, &changes);
+                println!();
+                println!(
+                    "Run {} to apply these changes.",
+                    "settings update".bright_cyan()
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Apply the local `_ricochet.toml` settings to the deployed item.
+pub async fn update(
+    config: &Config,
+    server_ref: Option<&str>,
+    path: Option<&Path>,
+    force: bool,
+    format: OutputFormat,
+) -> Result<()> {
+    let (id, local) = load_local(path)?;
+    let server_config = config.resolve_server(server_ref)?;
+    let client = RicochetClient::new(&server_config)?;
+    client.preflight_key_check().await?;
+
+    let (changes, patch) = diff_against_remote(&client, &id, &local).await?;
+
+    if changes.is_empty() {
+        println!("{} Settings already up to date", "✓".green().bold());
+        return Ok(());
+    }
+
+    print_changes(&id, &local.content.name, &changes);
+    println!();
+
+    if !force && !utils::confirm("Apply these changes?")? {
+        println!("{}", "Update cancelled".yellow());
+        return Ok(());
+    }
+
+    client
+        .update_settings(&id, &patch)
+        .await
+        .context("sending settings update")?;
+
+    match format {
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&patch)?),
+        OutputFormat::Yaml => println!("{}", serde_yaml::to_string(&patch)?),
+        OutputFormat::Table => {
+            println!(
+                "{} Settings updated for {}",
+                "✓".green().bold(),
+                id.bright_cyan()
+            )
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,6 +173,15 @@ enum ItemCommands {
         #[arg(short = 'p', long)]
         path: Option<std::path::PathBuf>,
     },
+    /// Show the diff between the local _ricochet.toml and the deployed item.
+    /// Use the `update` subcommand to apply it.
+    Settings {
+        #[command(subcommand)]
+        command: Option<SettingsCommands>,
+        /// Path to _ricochet.toml file
+        #[arg(short = 'p', long)]
+        path: Option<std::path::PathBuf>,
+    },
     /// Manage deployments for an app
     Deployment {
         #[command(subcommand)]
@@ -202,6 +211,15 @@ enum TaskCommands {
         /// Cron expression (e.g. "0 9 * * 1-5" for weekdays at 9am)
         schedule: String,
     },
+    /// Show the diff between the local _ricochet.toml and the deployed item.
+    /// Use the `update` subcommand to apply it.
+    Settings {
+        #[command(subcommand)]
+        command: Option<SettingsCommands>,
+        /// Path to _ricochet.toml file
+        #[arg(short = 'p', long)]
+        path: Option<std::path::PathBuf>,
+    },
     /// Manage deployments for a task
     Deployment {
         #[command(subcommand)]
@@ -224,6 +242,19 @@ enum DeploymentCommands {
     Get {
         /// Deployment ID (ULID)
         id: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum SettingsCommands {
+    /// Apply local _ricochet.toml settings to the server
+    Update {
+        /// Path to _ricochet.toml file
+        #[arg(short = 'p', long)]
+        path: Option<std::path::PathBuf>,
+        /// Skip the confirmation prompt
+        #[arg(short = 'f', long)]
+        force: bool,
     },
 }
 
@@ -362,6 +393,31 @@ async fn main() -> Result<()> {
                 )
                 .await?;
             }
+            ItemCommands::Settings { command, path } => match command {
+                None => {
+                    item::settings::preview(
+                        &config,
+                        cli.server.as_deref(),
+                        path.as_deref(),
+                        cli.format,
+                    )
+                    .await?;
+                }
+                Some(SettingsCommands::Update {
+                    path: update_path,
+                    force,
+                }) => {
+                    let resolved = update_path.or(path);
+                    item::settings::update(
+                        &config,
+                        cli.server.as_deref(),
+                        resolved.as_deref(),
+                        force,
+                        cli.format,
+                    )
+                    .await?;
+                }
+            },
             ItemCommands::Deployment { command } => match command {
                 DeploymentCommands::List { id, fields } => {
                     item::deployment::list_deployments(
@@ -401,6 +457,31 @@ async fn main() -> Result<()> {
                 )
                 .await?;
             }
+            TaskCommands::Settings { command, path } => match command {
+                None => {
+                    item::settings::preview(
+                        &config,
+                        cli.server.as_deref(),
+                        path.as_deref(),
+                        cli.format,
+                    )
+                    .await?;
+                }
+                Some(SettingsCommands::Update {
+                    path: update_path,
+                    force,
+                }) => {
+                    let resolved = update_path.or(path);
+                    item::settings::update(
+                        &config,
+                        cli.server.as_deref(),
+                        resolved.as_deref(),
+                        force,
+                        cli.format,
+                    )
+                    .await?;
+                }
+            },
             TaskCommands::Deployment { command } => match command {
                 DeploymentCommands::List { id, fields } => {
                     item::deployment::list_deployments(

--- a/tests/settings_test.rs
+++ b/tests/settings_test.rs
@@ -1,0 +1,75 @@
+use mockito::Server;
+use serde_json::json;
+use url::Url;
+
+fn client_for(server: &mockito::Server, key: &str) -> ricochet_cli::client::RicochetClient {
+    let config = ricochet_cli::config::Config::for_test(
+        Url::parse(&server.url()).unwrap(),
+        Some(key.to_string()),
+    );
+    let server_config = config.resolve_server(None).unwrap();
+    ricochet_cli::client::RicochetClient::new(&server_config).unwrap()
+}
+
+#[tokio::test]
+async fn test_update_settings_success() {
+    let mut server = Server::new_async().await;
+    let content_id = "01JSZAXZ3TSTAYXP56ARDVFJCJ";
+
+    let _m = server
+        .mock(
+            "PATCH",
+            format!("/api/v0/content/{}/settings", content_id).as_str(),
+        )
+        .match_header("authorization", "Key test_api_key")
+        .with_status(200)
+        .with_body("ok")
+        .create();
+
+    let client = client_for(&server, "test_api_key");
+    let patch = json!({"serve": {"min_instances": 2}});
+    let result = client.update_settings(content_id, &patch).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_update_settings_unauthorized() {
+    let mut server = Server::new_async().await;
+    let content_id = "01JSZAXZ3TSTAYXP56ARDVFJCJ";
+
+    let _m = server
+        .mock(
+            "PATCH",
+            format!("/api/v0/content/{}/settings", content_id).as_str(),
+        )
+        .match_header("authorization", "Key bad_key")
+        .with_status(401)
+        .with_body(json!({"error": "Unauthorized"}).to_string())
+        .create();
+
+    let client = client_for(&server, "bad_key");
+    let patch = json!({"serve": {"min_instances": 2}});
+    let result = client.update_settings(content_id, &patch).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_update_settings_not_found() {
+    let mut server = Server::new_async().await;
+    let content_id = "01JSZAXZ3TSTAYXP56NOTFOUND";
+
+    let _m = server
+        .mock(
+            "PATCH",
+            format!("/api/v0/content/{}/settings", content_id).as_str(),
+        )
+        .match_header("authorization", "Key test_api_key")
+        .with_status(404)
+        .with_body(json!({"error": "Content not found"}).to_string())
+        .create();
+
+    let client = client_for(&server, "test_api_key");
+    let patch = json!({"serve": {"min_instances": 2}});
+    let result = client.update_settings(content_id, &patch).await;
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Adds the `ricochet app/task settings update` command to allow patching app/task settings via the CLI.

<details>
<summary>Details</summary>


## Summary

Adds `ricochet app settings` / `ricochet task settings` to push the settings in a local `_ricochet.toml` to a deployed item via the `PATCH /api/v0/content/{id}/settings` endpoint.

- Bare `settings` previews: fetches the remote `_ricochet.toml`, computes a semantic per-field diff against the local file over the patchable subset (`content`, `serve`, `resources`, `deployment`, `static`, `packages`), and prints it. Read-only.
- `settings update` applies: shows the same diff, asks for confirmation (`-f`/`--force` skips), then sends the PATCH. No diff → no-op.
- Sections absent from the local TOML are never reset; only fields the user explicitly set and that differ are sent. `language`, `env_vars`, `schedule` (separate command), and `retention` are out of scope (not accepted by the endpoint).
- Retypes the previously-unused `RicochetClient::update_settings` to take `&serde_json::Value`.
- Available under both `app` and `task`; `--format json|yaml` emits the patch body. CLI reference regenerated.

Closes #61.

</details>