### PR TITLE
fix: adapt to ricochet-core ContentType method renames

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -378,7 +378,7 @@ fn static_settings(
 }
 
 fn schedule(content_type: &ContentType) -> anyhow::Result<Option<ScheduleSettings>> {
-    if !content_type.is_invokable() {
+    if !content_type.is_task() {
         return Ok(None);
     }
     let theme = ColorfulTheme::default();
@@ -477,7 +477,7 @@ pub fn init_rico_toml(
         packages,
     };
 
-    let serve = if content_type.is_service() {
+    let serve = if content_type.is_app() {
         Some(ServeSettings::default())
     } else {
         None


### PR DESCRIPTION
## Summary

Upstream `ricochet-core` renamed two `ContentType` methods, breaking the CLI build:

- `is_invokable()` → `is_task()`
- `is_service()` → `is_app()`

Both are pure renames with identical logic. Updated the two call sites in `src/commands/init.rs` and bumped `Cargo.lock` to the revision that introduced the rename (`5065680a` → `730945f2`, now reported as `ricochet-core` v0.11.0).

`cargo clippy --all-targets` passes clean.