### PR TITLE
chore(ci): gate release notes on macOS binaries succeeding

### DIFF
--- a/.crow/release-notes.yaml
+++ b/.crow/release-notes.yaml
@@ -17,6 +17,7 @@ when:
 
 depends_on:
   - binaries
+  - binaries-mac
 
 labels:
   agent: thumper


### PR DESCRIPTION
## Motivation

Follow-up to the 0.8.0 release confusion debacle (#172): a release should not publish user-facing release notes unless the release binaries actually built.

## What was already there

`release-notes.yaml` has depended on the `binaries` workflow since it was created in #113, which predates v0.8.0. So the Linux/Windows build succeeding already gated the notes. That did **not** prevent the 0.8.0 confusion.

## The actual gap

The macOS binaries build lives in a separate workflow, `binaries-mac.yaml`, running on a fragile self-hosted local runner. `release-notes` did not depend on it, so a broken/missing macOS (Homebrew) build could still trigger the AI docs release-notes PR and announce a release users could not install.

## Change

Add `binaries-mac` to the `release-notes` workflow's `depends_on`. On a tag, both the Linux/Windows and macOS builds must now succeed before the notes are generated.

Crow's workflow-level `depends_on` is a plain list of workflow names (`[]string` in the source; the config schema requires string items), so no per-dependency `optional` flag is available. On a bare `manual` event `binaries-mac` (like `binaries`) isn't part of the pipeline, so Crow already drops `release-notes` there via the existing `binaries` dependency; adding `binaries-mac` doesn't change that path.

## Behaviour change

On a real release, the docs release-notes PR is now only opened once **both** the Linux/Windows *and* macOS binary builds succeed.

Closes #172
