### PR TITLE
feat: fetch, add, delete, update, and overwrite env vars from CLI

### DIFF
--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -21,6 +21,11 @@ This document contains the help content for the `ricochet` command-line program.
 * [`ricochet app deployment`↴](#ricochet-app-deployment)
 * [`ricochet app deployment list`↴](#ricochet-app-deployment-list)
 * [`ricochet app deployment get`↴](#ricochet-app-deployment-get)
+* [`ricochet app env-vars`↴](#ricochet-app-env-vars)
+* [`ricochet app env-vars get`↴](#ricochet-app-env-vars-get)
+* [`ricochet app env-vars delete`↴](#ricochet-app-env-vars-delete)
+* [`ricochet app env-vars set`↴](#ricochet-app-env-vars-set)
+* [`ricochet app env-vars replace`↴](#ricochet-app-env-vars-replace)
 * [`ricochet task`↴](#ricochet-task)
 * [`ricochet task list`↴](#ricochet-task-list)
 * [`ricochet task toml`↴](#ricochet-task-toml)
@@ -31,6 +36,11 @@ This document contains the help content for the `ricochet` command-line program.
 * [`ricochet task deployment`↴](#ricochet-task-deployment)
 * [`ricochet task deployment list`↴](#ricochet-task-deployment-list)
 * [`ricochet task deployment get`↴](#ricochet-task-deployment-get)
+* [`ricochet task env-vars`↴](#ricochet-task-env-vars)
+* [`ricochet task env-vars get`↴](#ricochet-task-env-vars-get)
+* [`ricochet task env-vars delete`↴](#ricochet-task-env-vars-delete)
+* [`ricochet task env-vars set`↴](#ricochet-task-env-vars-set)
+* [`ricochet task env-vars replace`↴](#ricochet-task-env-vars-replace)
 * [`ricochet server`↴](#ricochet-server)
 * [`ricochet server list`↴](#ricochet-server-list)
 * [`ricochet server add`↴](#ricochet-server-add)
@@ -173,6 +183,7 @@ Manage deployed app items
 * `stop` — Stop a running instance, or all instances if no instance ID is given
 * `settings` — Show the diff between the local _ricochet.toml and the deployed item. Use the `update` subcommand to apply it
 * `deployment` — Manage deployments for an app
+* `env-vars` — Manage environment variables for an app
 
 
 
@@ -309,6 +320,90 @@ Get a specific deployment
 
 
 
+## `ricochet app env-vars`
+
+Manage environment variables for an app
+
+**Usage:** `ricochet app env-vars <COMMAND>`
+
+###### **Subcommands:**
+
+* `get` — List the names of an item's environment variables
+* `delete` — Delete an environment variable by name
+* `set` — Set (upsert) environment variables, leaving others untouched
+* `replace` — Replace all environment variables (any not listed are deleted)
+
+
+
+## `ricochet app env-vars get`
+
+List the names of an item's environment variables
+
+**Usage:** `ricochet app env-vars get [OPTIONS] [ID]`
+
+###### **Arguments:**
+
+* `<ID>` — Content item ID (ULID). If not provided, will read from local _ricochet.toml
+
+###### **Options:**
+
+* `-p`, `--path <PATH>` — Path to _ricochet.toml file
+
+
+
+## `ricochet app env-vars delete`
+
+Delete an environment variable by name
+
+**Usage:** `ricochet app env-vars delete [OPTIONS] <NAME>`
+
+###### **Arguments:**
+
+* `<NAME>` — Environment variable name
+
+###### **Options:**
+
+* `-i`, `--id <ID>` — Content item ID (ULID). If not provided, will read from local _ricochet.toml
+* `-p`, `--path <PATH>` — Path to _ricochet.toml file
+* `-f`, `--force` — Skip confirmation
+
+
+
+## `ricochet app env-vars set`
+
+Set (upsert) environment variables, leaving others untouched
+
+**Usage:** `ricochet app env-vars set [OPTIONS] <KEY[=VALUE]>...`
+
+###### **Arguments:**
+
+* `<KEY[=VALUE]>` — Variables to set. `KEY=VALUE` sets it directly. `KEY` alone resolves the value from .env, .Renviron, or the calling environment
+
+###### **Options:**
+
+* `-i`, `--id <ID>` — Content item ID (ULID). If not provided, will read from local _ricochet.toml
+* `-p`, `--path <PATH>` — Path to _ricochet.toml file
+
+
+
+## `ricochet app env-vars replace`
+
+Replace all environment variables (any not listed are deleted)
+
+**Usage:** `ricochet app env-vars replace [OPTIONS] [KEY[=VALUE]]...`
+
+###### **Arguments:**
+
+* `<KEY[=VALUE]>` — Variables to set. `KEY=VALUE` sets it directly. `KEY` alone resolves the value from .env, .Renviron, or the calling environment. Omit entirely to delete all environment variables
+
+###### **Options:**
+
+* `-i`, `--id <ID>` — Content item ID (ULID). If not provided, will read from local _ricochet.toml
+* `-p`, `--path <PATH>` — Path to _ricochet.toml file
+* `-f`, `--force` — Skip confirmation
+
+
+
 ## `ricochet task`
 
 Manage deployed task items
@@ -323,6 +418,7 @@ Manage deployed task items
 * `schedule` — Set or update the schedule for a task
 * `settings` — Show the diff between the local _ricochet.toml and the deployed item. Use the `update` subcommand to apply it
 * `deployment` — Manage deployments for a task
+* `env-vars` — Manage environment variables for a task
 
 
 
@@ -448,6 +544,90 @@ Get a specific deployment
 ###### **Arguments:**
 
 * `<ID>` — Deployment ID (ULID)
+
+
+
+## `ricochet task env-vars`
+
+Manage environment variables for a task
+
+**Usage:** `ricochet task env-vars <COMMAND>`
+
+###### **Subcommands:**
+
+* `get` — List the names of an item's environment variables
+* `delete` — Delete an environment variable by name
+* `set` — Set (upsert) environment variables, leaving others untouched
+* `replace` — Replace all environment variables (any not listed are deleted)
+
+
+
+## `ricochet task env-vars get`
+
+List the names of an item's environment variables
+
+**Usage:** `ricochet task env-vars get [OPTIONS] [ID]`
+
+###### **Arguments:**
+
+* `<ID>` — Content item ID (ULID). If not provided, will read from local _ricochet.toml
+
+###### **Options:**
+
+* `-p`, `--path <PATH>` — Path to _ricochet.toml file
+
+
+
+## `ricochet task env-vars delete`
+
+Delete an environment variable by name
+
+**Usage:** `ricochet task env-vars delete [OPTIONS] <NAME>`
+
+###### **Arguments:**
+
+* `<NAME>` — Environment variable name
+
+###### **Options:**
+
+* `-i`, `--id <ID>` — Content item ID (ULID). If not provided, will read from local _ricochet.toml
+* `-p`, `--path <PATH>` — Path to _ricochet.toml file
+* `-f`, `--force` — Skip confirmation
+
+
+
+## `ricochet task env-vars set`
+
+Set (upsert) environment variables, leaving others untouched
+
+**Usage:** `ricochet task env-vars set [OPTIONS] <KEY[=VALUE]>...`
+
+###### **Arguments:**
+
+* `<KEY[=VALUE]>` — Variables to set. `KEY=VALUE` sets it directly. `KEY` alone resolves the value from .env, .Renviron, or the calling environment
+
+###### **Options:**
+
+* `-i`, `--id <ID>` — Content item ID (ULID). If not provided, will read from local _ricochet.toml
+* `-p`, `--path <PATH>` — Path to _ricochet.toml file
+
+
+
+## `ricochet task env-vars replace`
+
+Replace all environment variables (any not listed are deleted)
+
+**Usage:** `ricochet task env-vars replace [OPTIONS] [KEY[=VALUE]]...`
+
+###### **Arguments:**
+
+* `<KEY[=VALUE]>` — Variables to set. `KEY=VALUE` sets it directly. `KEY` alone resolves the value from .env, .Renviron, or the calling environment. Omit entirely to delete all environment variables
+
+###### **Options:**
+
+* `-i`, `--id <ID>` — Content item ID (ULID). If not provided, will read from local _ricochet.toml
+* `-p`, `--path <PATH>` — Path to _ricochet.toml file
+* `-f`, `--force` — Skip confirmation
 
 
 

--- a/src/app/instances.rs
+++ b/src/app/instances.rs
@@ -2,36 +2,9 @@ use anyhow::Result;
 use colored::Colorize;
 use comfy_table::{Cell, Color, Table, presets::UTF8_FULL};
 use jiff::Timestamp;
-use ricochet_core::content::ContentItem;
-use std::{
-    fs::read_to_string,
-    path::{Path, PathBuf},
-};
+use std::path::Path;
 
-use crate::{OutputFormat, client::RicochetClient, config::Config, utils};
-
-fn resolve_id(id: Option<&str>, path: Option<&Path>) -> Result<String> {
-    match id {
-        Some(id) => Ok(id.to_string()),
-        None => {
-            let toml_path = path
-                .map(|p| p.to_path_buf())
-                .unwrap_or(PathBuf::from("_ricochet.toml"));
-            if !toml_path.exists() {
-                anyhow::bail!(
-                    "{} Provide either an item ID or a path to a `_ricochet.toml` file.",
-                    "⚠".yellow()
-                );
-            }
-            let toml = read_to_string(toml_path)?;
-            let item = ContentItem::from_toml(&toml)?;
-            let Some(id) = item.content.id else {
-                anyhow::bail!("Provided _ricochet.toml does not have an item ID")
-            };
-            Ok(id)
-        }
-    }
-}
+use crate::{OutputFormat, client::RicochetClient, config::Config, item::resolve_id, utils};
 
 pub async fn list_instances(
     config: &Config,

--- a/src/client.rs
+++ b/src/client.rs
@@ -204,7 +204,8 @@ impl RicochetClient {
 
         // Create a tar bundle from the directory
         pb.set_message("Creating bundle...");
-        let tar_path = std::env::temp_dir().join(format!("ricochet-{}.tar.gz", ulid::Ulid::generate()));
+        let tar_path =
+            std::env::temp_dir().join(format!("ricochet-{}.tar.gz", ulid::Ulid::generate()));
         crate::utils::create_bundle(path, &tar_path, include, exclude, extra_root_files, debug)?;
 
         // Get file size for progress tracking
@@ -458,6 +459,33 @@ impl RicochetClient {
         let response = self
             .client
             .get(url)
+            .header("Authorization", format!("Key {}", self.api_key))
+            .send()
+            .await?;
+        Self::handle_response(response).await
+    }
+
+    /// List the names of an item's environment variables.
+    pub async fn get_env_vars(&self, id: &str) -> Result<Vec<String>> {
+        let mut url = self.base_url.clone();
+        url.set_path(&format!("/api/v0/content/{}/env-vars", id));
+        let response = self
+            .client
+            .get(url)
+            .header("Authorization", format!("Key {}", self.api_key))
+            .send()
+            .await?;
+        Self::handle_response(response).await
+    }
+
+    /// Delete an environment variable by name. Returns the item's remaining
+    /// environment variable names.
+    pub async fn delete_env_var(&self, id: &str, name: &str) -> Result<Vec<String>> {
+        let mut url = self.base_url.clone();
+        url.set_path(&format!("/api/v0/content/{}/env-vars/{}", id, name));
+        let response = self
+            .client
+            .delete(url)
             .header("Authorization", format!("Key {}", self.api_key))
             .send()
             .await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -492,6 +492,48 @@ impl RicochetClient {
         Self::handle_response(response).await
     }
 
+    /// Upsert (PATCH) environment variables. Existing variables not included
+    /// are left untouched. Names and values must already be RSA-OAEP/SHA-256
+    /// encrypted and base64 encoded. Returns the item's remaining
+    /// environment variable names.
+    pub async fn upsert_env_vars(
+        &self,
+        id: &str,
+        encrypted: &crate::crypto::RsaEncryptedEnvVars,
+    ) -> Result<Vec<String>> {
+        let mut url = self.base_url.clone();
+        url.set_path(&format!("/api/v0/content/{}/env-vars", id));
+        let response = self
+            .client
+            .patch(url)
+            .header("Authorization", format!("Key {}", self.api_key))
+            .json(encrypted)
+            .send()
+            .await?;
+        Self::handle_response(response).await
+    }
+
+    /// Replace (PUT) all environment variables. Any variable not included is
+    /// deleted. Names and values must already be RSA-OAEP/SHA-256 encrypted
+    /// and base64 encoded. Returns the item's remaining environment variable
+    /// names.
+    pub async fn replace_env_vars(
+        &self,
+        id: &str,
+        encrypted: &crate::crypto::RsaEncryptedEnvVars,
+    ) -> Result<Vec<String>> {
+        let mut url = self.base_url.clone();
+        url.set_path(&format!("/api/v0/content/{}/env-vars", id));
+        let response = self
+            .client
+            .put(url)
+            .header("Authorization", format!("Key {}", self.api_key))
+            .json(encrypted)
+            .send()
+            .await?;
+        Self::handle_response(response).await
+    }
+
     pub async fn get_ricochet_toml(&self, id: &str) -> Result<String> {
         let mut url = self.base_url.clone();
         url.set_path(&format!("/api/v0/content/{}/toml", id));

--- a/src/client.rs
+++ b/src/client.rs
@@ -492,10 +492,8 @@ impl RicochetClient {
         Self::handle_response(response).await
     }
 
-    /// Upsert (PATCH) environment variables. Existing variables not included
-    /// are left untouched. Names and values must already be RSA-OAEP/SHA-256
-    /// encrypted and base64 encoded. Returns the item's remaining
-    /// environment variable names.
+    /// Upsert environment variables, leaving others untouched. Returns the
+    /// item's remaining environment variable names.
     pub async fn upsert_env_vars(
         &self,
         id: &str,
@@ -513,10 +511,8 @@ impl RicochetClient {
         Self::handle_response(response).await
     }
 
-    /// Replace (PUT) all environment variables. Any variable not included is
-    /// deleted. Names and values must already be RSA-OAEP/SHA-256 encrypted
-    /// and base64 encoded. Returns the item's remaining environment variable
-    /// names.
+    /// Replace all environment variables. Returns the item's remaining
+    /// environment variable names.
     pub async fn replace_env_vars(
         &self,
         id: &str,

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,8 +1,9 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
 use rsa::pkcs1::DecodeRsaPublicKey;
-use rsa::sha2::Sha256;
+use rsa::sha2::{Digest, Sha256};
+use rsa::traits::PublicKeyParts;
 use rsa::{Oaep, RsaPublicKey};
 use serde::Serialize;
 use std::collections::HashMap;
@@ -16,14 +17,35 @@ pub fn parse_public_key_pem(pem: &str) -> Result<RsaPublicKey> {
     Ok(RsaPublicKey::from_pkcs1_pem(pem.trim())?)
 }
 
+/// The largest plaintext RSA-OAEP with SHA-256 can encrypt under `pub_key`.
+/// 190 bytes for the 2048-bit keys the server issues.
+pub fn max_plaintext_len(pub_key: &RsaPublicKey) -> usize {
+    pub_key
+        .size()
+        .saturating_sub(2 * <Sha256 as Digest>::output_size() + 2)
+}
+
 pub fn encrypt_env_vars(
     pub_key: &RsaPublicKey,
     vars: &HashMap<String, String>,
 ) -> Result<RsaEncryptedEnvVars> {
     use rsa::rand_core::OsRng;
+    let max_len = max_plaintext_len(pub_key);
     let mut rng = OsRng;
     let mut out = HashMap::new();
     for (name, value) in vars {
+        let name_len = name.len();
+        if name_len > max_len {
+            bail!(
+                "environment variable name `{name}` is {name_len} bytes; the server's public key can encrypt at most {max_len} bytes"
+            );
+        }
+        let value_len = value.len();
+        if value_len > max_len {
+            bail!(
+                "value for environment variable `{name}` is {value_len} bytes; the server's public key can encrypt at most {max_len} bytes"
+            );
+        }
         let enc_name = pub_key.encrypt(&mut rng, Oaep::new::<Sha256>(), name.as_bytes())?;
         let enc_value = pub_key.encrypt(&mut rng, Oaep::new::<Sha256>(), value.as_bytes())?;
         out.insert(
@@ -79,6 +101,26 @@ mod tests {
             recovered.insert(name, value);
         }
         assert_eq!(recovered, vars);
+    }
+
+    #[test]
+    fn oversized_value_names_the_variable_and_the_limit() {
+        let mut rng = OsRng;
+        let priv_key = RsaPrivateKey::new(&mut rng, 2048).unwrap();
+        let pub_key = RsaPublicKey::from(&priv_key);
+        let max_len = max_plaintext_len(&pub_key);
+        assert_eq!(max_len, 190);
+
+        let mut vars = HashMap::new();
+        vars.insert("JWT".to_string(), "x".repeat(max_len + 1));
+        let err = encrypt_env_vars(&pub_key, &vars).unwrap_err().to_string();
+        assert!(err.contains("JWT"), "{err}");
+        assert!(err.contains("191 bytes"), "{err}");
+        assert!(err.contains("at most 190 bytes"), "{err}");
+
+        // A value of exactly the limit still encrypts.
+        vars.insert("JWT".to_string(), "x".repeat(max_len));
+        assert!(encrypt_env_vars(&pub_key, &vars).is_ok());
     }
 
     #[test]

--- a/src/env_vars.rs
+++ b/src/env_vars.rs
@@ -47,7 +47,7 @@ fn strip_quotes(value: &str) -> &str {
     }
 }
 
-/// Resolve `--env` entries into concrete key/value pairs.
+/// Resolve env var entries into concrete key/value pairs.
 ///
 /// `KEY=VALUE` is taken literally. `KEY` alone is looked up in `.env`, then
 /// `.Renviron` (both in `dir`), then the process environment; an unresolved
@@ -68,7 +68,7 @@ pub fn resolve_env_vars(entries: &[String], dir: &Path) -> Result<HashMap<String
                     result.insert(key.to_string(), v);
                 }
                 None => bail!(
-                    "env var `{key}` not found in .env, .Renviron, or the environment; pass it explicitly as `--env {key}=value`"
+                    "env var `{key}` not found in .env, .Renviron, or the environment; pass it explicitly as `{key}=value`"
                 ),
             }
         }
@@ -173,7 +173,7 @@ NOT A KEY=ignored
             .unwrap_err()
             .to_string();
         assert!(err.contains("DEFINITELY_MISSING_KEY_XYZ"));
-        assert!(err.contains("--env DEFINITELY_MISSING_KEY_XYZ=value"));
+        assert!(err.contains("`DEFINITELY_MISSING_KEY_XYZ=value`"));
     }
 
     #[test]

--- a/src/item/env_vars.rs
+++ b/src/item/env_vars.rs
@@ -142,10 +142,6 @@ pub async fn set_env_vars(
     env: &[String],
     format: OutputFormat,
 ) -> Result<()> {
-    if env.is_empty() {
-        anyhow::bail!("Provide at least one `--env KEY[=VALUE]`");
-    }
-
     let id = resolve_id(id, path)?;
     let server_config = config.resolve_server(server_ref)?;
     let client = RicochetClient::new(&server_config)?;
@@ -155,7 +151,7 @@ pub async fn set_env_vars(
     let names = client.upsert_env_vars(&id, &encrypted).await?;
 
     println!(
-        "{} Environment variable(s) set; instances will restart to pick them up",
+        "{} Environment variable(s) set. Instances will restart to pick them up",
         "✓".green().bold(),
     );
 
@@ -174,7 +170,8 @@ pub async fn replace_env_vars(
     let id = resolve_id(id, path)?;
 
     if !force {
-        let message = "This replaces ALL environment variables; anything not listed will be deleted. Continue?";
+        let message =
+            "This replaces all environment variables. Anything not listed gets deleted. Continue?";
         if !utils::confirm(message)? {
             println!("{}", "Replace cancelled".yellow());
             return Ok(());
@@ -189,7 +186,7 @@ pub async fn replace_env_vars(
     let names = client.replace_env_vars(&id, &encrypted).await?;
 
     println!(
-        "{} Environment variables replaced; instances will restart to pick them up",
+        "{} Environment variables replaced. Instances will restart to pick them up",
         "✓".green().bold(),
     );
 

--- a/src/item/env_vars.rs
+++ b/src/item/env_vars.rs
@@ -103,7 +103,7 @@ pub async fn delete_env_var(
     if !force {
         let message = format!("Are you sure you want to delete environment variable '{name}'?");
         if !utils::confirm(&message)? {
-            println!("{}", "Deletion cancelled".yellow());
+            eprintln!("{}", "Deletion cancelled".yellow());
             return Ok(());
         }
     }
@@ -114,7 +114,7 @@ pub async fn delete_env_var(
 
     let names = client.delete_env_var(&id, name).await?;
 
-    println!(
+    eprintln!(
         "{} Environment variable '{}' deleted",
         "✓".green().bold(),
         name.bright_cyan()
@@ -150,7 +150,7 @@ pub async fn set_env_vars(
     let encrypted = encrypt_entries(&client, env, &env_dir(path)).await?;
     let names = client.upsert_env_vars(&id, &encrypted).await?;
 
-    println!(
+    eprintln!(
         "{} Environment variable(s) set. Instances will restart to pick them up",
         "✓".green().bold(),
     );
@@ -173,7 +173,7 @@ pub async fn replace_env_vars(
         let message =
             "This replaces all environment variables. Anything not listed gets deleted. Continue?";
         if !utils::confirm(message)? {
-            println!("{}", "Replace cancelled".yellow());
+            eprintln!("{}", "Replace cancelled".yellow());
             return Ok(());
         }
     }
@@ -185,7 +185,7 @@ pub async fn replace_env_vars(
     let encrypted = encrypt_entries(&client, env, &env_dir(path)).await?;
     let names = client.replace_env_vars(&id, &encrypted).await?;
 
-    println!(
+    eprintln!(
         "{} Environment variables replaced. Instances will restart to pick them up",
         "✓".green().bold(),
     );

--- a/src/item/env_vars.rs
+++ b/src/item/env_vars.rs
@@ -1,0 +1,114 @@
+use crate::{OutputFormat, client::RicochetClient, config::Config, utils};
+use anyhow::Result;
+use colored::Colorize;
+use comfy_table::{Table, presets::UTF8_FULL};
+use ricochet_core::content::ContentItem;
+use std::{
+    fs::read_to_string,
+    path::{Path, PathBuf},
+};
+
+fn resolve_id(id: Option<&str>, path: Option<&Path>) -> Result<String> {
+    match id {
+        Some(id) => Ok(id.to_string()),
+        None => {
+            let toml_path = path
+                .map(|p| p.to_path_buf())
+                .unwrap_or(PathBuf::from("_ricochet.toml"));
+            if !toml_path.exists() {
+                anyhow::bail!(
+                    "{} Provide either an item ID or a path to a `_ricochet.toml` file.",
+                    "⚠".yellow()
+                );
+            }
+            let toml = read_to_string(toml_path)?;
+            let item = ContentItem::from_toml(&toml)?;
+            let Some(id) = item.content.id else {
+                anyhow::bail!("Provided _ricochet.toml does not have an item ID")
+            };
+            Ok(id)
+        }
+    }
+}
+
+fn print_names(server_url: &str, names: &[String], format: OutputFormat) -> Result<()> {
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&names)?);
+        }
+        OutputFormat::Yaml => {
+            println!("{}", serde_yaml::to_string(&names)?);
+        }
+        OutputFormat::Table => {
+            println!("{}", server_url.italic().dimmed());
+
+            if names.is_empty() {
+                println!("{}", "No environment variables found.".yellow());
+                return Ok(());
+            }
+
+            let mut table = Table::new();
+            table.load_preset(UTF8_FULL);
+            table.set_header(vec!["Name"]);
+            for name in names {
+                table.add_row(vec![name]);
+            }
+
+            println!("{}", table);
+            println!("\n{} environment variable(s)", names.len());
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn get_env_vars(
+    config: &Config,
+    server_ref: Option<&str>,
+    id: Option<&str>,
+    path: Option<&Path>,
+    format: OutputFormat,
+) -> Result<()> {
+    let id = resolve_id(id, path)?;
+    let server_config = config.resolve_server(server_ref)?;
+    let client = RicochetClient::new(&server_config)?;
+    client.preflight_key_check().await?;
+
+    let names = client.get_env_vars(&id).await?;
+
+    print_names(server_config.url.as_str(), &names, format)
+}
+
+pub async fn delete_env_var(
+    config: &Config,
+    server_ref: Option<&str>,
+    id: Option<&str>,
+    path: Option<&Path>,
+    name: &str,
+    force: bool,
+    format: OutputFormat,
+) -> Result<()> {
+    let id = resolve_id(id, path)?;
+
+    if !force {
+        let message = format!("Are you sure you want to delete environment variable '{name}'?");
+        if !utils::confirm(&message)? {
+            println!("{}", "Deletion cancelled".yellow());
+            return Ok(());
+        }
+    }
+
+    let server_config = config.resolve_server(server_ref)?;
+    let client = RicochetClient::new(&server_config)?;
+    client.preflight_key_check().await?;
+
+    let names = client.delete_env_var(&id, name).await?;
+
+    println!(
+        "{} Environment variable '{}' deleted",
+        "✓".green().bold(),
+        name.bright_cyan()
+    );
+
+    print_names(server_config.url.as_str(), &names, format)
+}

--- a/src/item/env_vars.rs
+++ b/src/item/env_vars.rs
@@ -1,35 +1,8 @@
-use crate::{OutputFormat, client::RicochetClient, config::Config, utils};
+use crate::{OutputFormat, client::RicochetClient, config::Config, item::resolve_id, utils};
 use anyhow::Result;
 use colored::Colorize;
 use comfy_table::{Table, presets::UTF8_FULL};
-use ricochet_core::content::ContentItem;
-use std::{
-    fs::read_to_string,
-    path::{Path, PathBuf},
-};
-
-fn resolve_id(id: Option<&str>, path: Option<&Path>) -> Result<String> {
-    match id {
-        Some(id) => Ok(id.to_string()),
-        None => {
-            let toml_path = path
-                .map(|p| p.to_path_buf())
-                .unwrap_or(PathBuf::from("_ricochet.toml"));
-            if !toml_path.exists() {
-                anyhow::bail!(
-                    "{} Provide either an item ID or a path to a `_ricochet.toml` file.",
-                    "⚠".yellow()
-                );
-            }
-            let toml = read_to_string(toml_path)?;
-            let item = ContentItem::from_toml(&toml)?;
-            let Some(id) = item.content.id else {
-                anyhow::bail!("Provided _ricochet.toml does not have an item ID")
-            };
-            Ok(id)
-        }
-    }
-}
+use std::path::{Path, PathBuf};
 
 /// Directory to resolve `.env` / `.Renviron` lookups against for a bare `KEY`
 /// entry: the directory containing `path`, if given, otherwise the current

--- a/src/item/env_vars.rs
+++ b/src/item/env_vars.rs
@@ -31,9 +31,9 @@ fn resolve_id(id: Option<&str>, path: Option<&Path>) -> Result<String> {
     }
 }
 
-/// Directory to resolve `.env` / `.Renviron` lookups against for a `--env
-/// KEY` (no value) entry: the directory containing `path`, if given,
-/// otherwise the current directory.
+/// Directory to resolve `.env` / `.Renviron` lookups against for a bare `KEY`
+/// entry: the directory containing `path`, if given, otherwise the current
+/// directory.
 fn env_dir(path: Option<&Path>) -> PathBuf {
     path.and_then(|p| p.parent())
         .filter(|p| !p.as_os_str().is_empty())
@@ -123,7 +123,7 @@ pub async fn delete_env_var(
     print_names(server_config.url.as_str(), &names, format)
 }
 
-/// Encrypt the resolved `--env` entries with the server's public key.
+/// Encrypt the resolved entries with the server's public key.
 async fn encrypt_entries(
     client: &RicochetClient,
     env: &[String],

--- a/src/item/env_vars.rs
+++ b/src/item/env_vars.rs
@@ -31,6 +31,16 @@ fn resolve_id(id: Option<&str>, path: Option<&Path>) -> Result<String> {
     }
 }
 
+/// Directory to resolve `.env` / `.Renviron` lookups against for a `--env
+/// KEY` (no value) entry: the directory containing `path`, if given,
+/// otherwise the current directory.
+fn env_dir(path: Option<&Path>) -> PathBuf {
+    path.and_then(|p| p.parent())
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
 fn print_names(server_url: &str, names: &[String], format: OutputFormat) -> Result<()> {
     match format {
         OutputFormat::Json => {
@@ -108,6 +118,79 @@ pub async fn delete_env_var(
         "{} Environment variable '{}' deleted",
         "✓".green().bold(),
         name.bright_cyan()
+    );
+
+    print_names(server_config.url.as_str(), &names, format)
+}
+
+/// Encrypt the resolved `--env` entries with the server's public key.
+async fn encrypt_entries(
+    client: &RicochetClient,
+    env: &[String],
+    dir: &Path,
+) -> Result<crate::crypto::RsaEncryptedEnvVars> {
+    let resolved = crate::env_vars::resolve_env_vars(env, dir)?;
+    let pub_key = client.get_public_key().await?;
+    crate::crypto::encrypt_env_vars(&pub_key, &resolved)
+}
+
+pub async fn set_env_vars(
+    config: &Config,
+    server_ref: Option<&str>,
+    id: Option<&str>,
+    path: Option<&Path>,
+    env: &[String],
+    format: OutputFormat,
+) -> Result<()> {
+    if env.is_empty() {
+        anyhow::bail!("Provide at least one `--env KEY[=VALUE]`");
+    }
+
+    let id = resolve_id(id, path)?;
+    let server_config = config.resolve_server(server_ref)?;
+    let client = RicochetClient::new(&server_config)?;
+    client.preflight_key_check().await?;
+
+    let encrypted = encrypt_entries(&client, env, &env_dir(path)).await?;
+    let names = client.upsert_env_vars(&id, &encrypted).await?;
+
+    println!(
+        "{} Environment variable(s) set; instances will restart to pick them up",
+        "✓".green().bold(),
+    );
+
+    print_names(server_config.url.as_str(), &names, format)
+}
+
+pub async fn replace_env_vars(
+    config: &Config,
+    server_ref: Option<&str>,
+    id: Option<&str>,
+    path: Option<&Path>,
+    env: &[String],
+    force: bool,
+    format: OutputFormat,
+) -> Result<()> {
+    let id = resolve_id(id, path)?;
+
+    if !force {
+        let message = "This replaces ALL environment variables; anything not listed will be deleted. Continue?";
+        if !utils::confirm(message)? {
+            println!("{}", "Replace cancelled".yellow());
+            return Ok(());
+        }
+    }
+
+    let server_config = config.resolve_server(server_ref)?;
+    let client = RicochetClient::new(&server_config)?;
+    client.preflight_key_check().await?;
+
+    let encrypted = encrypt_entries(&client, env, &env_dir(path)).await?;
+    let names = client.replace_env_vars(&id, &encrypted).await?;
+
+    println!(
+        "{} Environment variables replaced; instances will restart to pick them up",
+        "✓".green().bold(),
     );
 
     print_names(server_config.url.as_str(), &names, format)

--- a/src/item/mod.rs
+++ b/src/item/mod.rs
@@ -4,3 +4,101 @@ pub mod invoke;
 pub mod schedule;
 pub mod settings;
 pub mod toml;
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use ricochet_core::content::ContentItem;
+use std::{
+    fs::read_to_string,
+    path::{Path, PathBuf},
+};
+
+/// Load the local `_ricochet.toml`, returning its content ID and parsed item.
+pub fn load_local(path: Option<&Path>) -> Result<(String, ContentItem)> {
+    let toml_path = path
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("_ricochet.toml"));
+    if toml_path.is_dir() {
+        anyhow::bail!(
+            "{} {} is a directory. Point --path at the `_ricochet.toml` file itself.",
+            "⚠".yellow(),
+            toml_path.display()
+        );
+    }
+    if !toml_path.exists() {
+        anyhow::bail!(
+            "{} No `_ricochet.toml` found at {}. Provide one with --path.",
+            "⚠".yellow(),
+            toml_path.display()
+        );
+    }
+    let toml = read_to_string(&toml_path).context("reading local _ricochet.toml")?;
+    let item = ContentItem::from_toml(&toml).context("parsing local _ricochet.toml")?;
+    let Some(id) = item.content.id.clone() else {
+        anyhow::bail!("Local _ricochet.toml has no item ID. Deploy the item first.");
+    };
+    Ok((id, item))
+}
+
+/// Take the content ID as given, or read it from the local `_ricochet.toml`.
+pub fn resolve_id(id: Option<&str>, path: Option<&Path>) -> Result<String> {
+    match id {
+        Some(id) => Ok(id.to_string()),
+        None => load_local(path)
+            .map(|(id, _)| id)
+            .context("provide either an item ID or a path to a `_ricochet.toml` file"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    const LOCAL_TOML: &str = r#"[content]
+id = "01KE52BY41EQ7NE89K7Z5MMZ84"
+name = "local-app"
+entrypoint = "app.R"
+access_type = "external"
+content_type = "shiny"
+
+[language]
+name = "r"
+packages = "renv.lock"
+"#;
+
+    #[test]
+    fn reads_the_id_from_the_given_path() {
+        let dir = TempDir::new().unwrap();
+        let toml_path = dir.path().join("_ricochet.toml");
+        fs::write(&toml_path, LOCAL_TOML).unwrap();
+
+        let (id, item) = load_local(Some(&toml_path)).unwrap();
+        assert_eq!(id, "01KE52BY41EQ7NE89K7Z5MMZ84");
+        assert_eq!(item.content.name, "local-app");
+        assert_eq!(resolve_id(None, Some(&toml_path)).unwrap(), id);
+    }
+
+    #[test]
+    fn directory_path_says_so() {
+        let dir = TempDir::new().unwrap();
+        let err = load_local(Some(dir.path())).unwrap_err().to_string();
+        assert!(err.contains("is a directory"), "{err}");
+    }
+
+    #[test]
+    fn missing_file_names_the_path() {
+        let dir = TempDir::new().unwrap();
+        let toml_path = dir.path().join("_ricochet.toml");
+        let err = load_local(Some(&toml_path)).unwrap_err().to_string();
+        assert!(err.contains(&toml_path.display().to_string()), "{err}");
+    }
+
+    #[test]
+    fn explicit_id_never_touches_the_filesystem() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("nope.toml");
+        assert_eq!(resolve_id(Some("ABC"), Some(&missing)).unwrap(), "ABC");
+    }
+}

--- a/src/item/mod.rs
+++ b/src/item/mod.rs
@@ -1,4 +1,5 @@
 pub mod deployment;
+pub mod env_vars;
 pub mod invoke;
 pub mod schedule;
 pub mod settings;

--- a/src/item/settings.rs
+++ b/src/item/settings.rs
@@ -2,38 +2,15 @@ use anyhow::{Context, Result};
 use colored::Colorize;
 use ricochet_core::content::ContentItem;
 use serde_json::{Map, Value, json};
-use std::{
-    fs::read_to_string,
-    path::{Path, PathBuf},
-};
+use std::path::Path;
 
-use crate::{OutputFormat, client::RicochetClient, config::Config, utils};
+use crate::{OutputFormat, client::RicochetClient, config::Config, item::load_local, utils};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct FieldChange {
     pub field: String,
     pub from: String,
     pub to: String,
-}
-
-/// Load the local `_ricochet.toml`, returning its content ID and parsed item.
-fn load_local(path: Option<&Path>) -> Result<(String, ContentItem)> {
-    let toml_path = path
-        .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("_ricochet.toml"));
-    if !toml_path.exists() {
-        anyhow::bail!(
-            "{} No `_ricochet.toml` found at {}. Provide one with --path.",
-            "⚠".yellow(),
-            toml_path.display()
-        );
-    }
-    let toml = read_to_string(&toml_path)?;
-    let item = ContentItem::from_toml(&toml).context("parsing local _ricochet.toml")?;
-    let Some(id) = item.content.id.clone() else {
-        anyhow::bail!("Local _ricochet.toml has no item ID. Deploy the item first.");
-    };
-    Ok((id, item))
 }
 
 /// Print the change list as a human-readable diff (remote → local).

--- a/src/item/toml.rs
+++ b/src/item/toml.rs
@@ -1,7 +1,5 @@
-use crate::{client::RicochetClient, config::Config};
-use colored::Colorize;
-use ricochet_core::content::ContentItem;
-use std::{fs::read_to_string, path::PathBuf};
+use crate::{client::RicochetClient, config::Config, item::resolve_id};
+use std::path::PathBuf;
 
 pub async fn get_toml(
     config: &Config,
@@ -12,25 +10,7 @@ pub async fn get_toml(
     let client = RicochetClient::new(&server_config)?;
     client.preflight_key_check().await?;
 
-    let id = match id {
-        Some(id) => id,
-        None => {
-            let toml_path = path.unwrap_or(PathBuf::from("_ricochet.toml"));
-            if !toml_path.exists() {
-                anyhow::bail!(
-                    "{} Provide either an item ID or a path to a `_ricochet.toml` file.",
-                    "⚠".yellow()
-                );
-            }
-            let toml = read_to_string(toml_path)?;
-            let item = ContentItem::from_toml(&toml)?;
-            let Some(id) = item.content.id else {
-                anyhow::bail!("Provided _ricochet.toml does not have an item ID")
-            };
-
-            id
-        }
-    };
+    let id = resolve_id(id.as_deref(), path.as_deref())?;
 
     println!("{}", client.get_ricochet_toml(&id).await?);
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,6 +282,36 @@ enum EnvVarsCommands {
         #[arg(short = 'f', long)]
         force: bool,
     },
+    /// Set (upsert) environment variables, leaving others untouched
+    Set {
+        /// Variables to set. `KEY=VALUE` sets it directly. `KEY` alone resolves
+        /// the value from .env, .Renviron, or the calling environment.
+        #[arg(value_name = "KEY[=VALUE]", required = true)]
+        env: Vec<String>,
+        /// Content item ID (ULID). If not provided, will read from local _ricochet.toml
+        #[arg(short = 'i', long)]
+        id: Option<String>,
+        /// Path to _ricochet.toml file
+        #[arg(short = 'p', long)]
+        path: Option<std::path::PathBuf>,
+    },
+    /// Replace all environment variables (any not listed are deleted)
+    Replace {
+        /// Variables to set. `KEY=VALUE` sets it directly. `KEY` alone resolves
+        /// the value from .env, .Renviron, or the calling environment. Omit
+        /// entirely to delete all environment variables.
+        #[arg(value_name = "KEY[=VALUE]")]
+        env: Vec<String>,
+        /// Content item ID (ULID). If not provided, will read from local _ricochet.toml
+        #[arg(short = 'i', long)]
+        id: Option<String>,
+        /// Path to _ricochet.toml file
+        #[arg(short = 'p', long)]
+        path: Option<std::path::PathBuf>,
+        /// Skip confirmation
+        #[arg(short = 'f', long)]
+        force: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -531,6 +561,34 @@ async fn main() -> Result<()> {
                     )
                     .await?;
                 }
+                EnvVarsCommands::Set { id, path, env } => {
+                    item::env_vars::set_env_vars(
+                        &config,
+                        cli.server.as_deref(),
+                        id.as_deref(),
+                        path.as_deref(),
+                        &env,
+                        cli.format,
+                    )
+                    .await?;
+                }
+                EnvVarsCommands::Replace {
+                    id,
+                    path,
+                    env,
+                    force,
+                } => {
+                    item::env_vars::replace_env_vars(
+                        &config,
+                        cli.server.as_deref(),
+                        id.as_deref(),
+                        path.as_deref(),
+                        &env,
+                        force,
+                        cli.format,
+                    )
+                    .await?;
+                }
             },
         },
         Some(Commands::Task { command }) => match command {
@@ -636,6 +694,34 @@ async fn main() -> Result<()> {
                         id.as_deref(),
                         path.as_deref(),
                         &name,
+                        force,
+                        cli.format,
+                    )
+                    .await?;
+                }
+                EnvVarsCommands::Set { id, path, env } => {
+                    item::env_vars::set_env_vars(
+                        &config,
+                        cli.server.as_deref(),
+                        id.as_deref(),
+                        path.as_deref(),
+                        &env,
+                        cli.format,
+                    )
+                    .await?;
+                }
+                EnvVarsCommands::Replace {
+                    id,
+                    path,
+                    env,
+                    force,
+                } => {
+                    item::env_vars::replace_env_vars(
+                        &config,
+                        cli.server.as_deref(),
+                        id.as_deref(),
+                        path.as_deref(),
+                        &env,
                         force,
                         cli.format,
                     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,6 +195,11 @@ enum ItemCommands {
         #[command(subcommand)]
         command: DeploymentCommands,
     },
+    /// Manage environment variables for an app
+    EnvVars {
+        #[command(subcommand)]
+        command: EnvVarsCommands,
+    },
 }
 
 #[derive(Subcommand)]
@@ -245,6 +250,37 @@ enum TaskCommands {
     Deployment {
         #[command(subcommand)]
         command: DeploymentCommands,
+    },
+    /// Manage environment variables for a task
+    EnvVars {
+        #[command(subcommand)]
+        command: EnvVarsCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum EnvVarsCommands {
+    /// List the names of an item's environment variables
+    Get {
+        /// Content item ID (ULID). If not provided, will read from local _ricochet.toml
+        id: Option<String>,
+        /// Path to _ricochet.toml file
+        #[arg(short = 'p', long)]
+        path: Option<std::path::PathBuf>,
+    },
+    /// Delete an environment variable by name
+    Delete {
+        /// Environment variable name
+        name: String,
+        /// Content item ID (ULID). If not provided, will read from local _ricochet.toml
+        #[arg(short = 'i', long)]
+        id: Option<String>,
+        /// Path to _ricochet.toml file
+        #[arg(short = 'p', long)]
+        path: Option<std::path::PathBuf>,
+        /// Skip confirmation
+        #[arg(short = 'f', long)]
+        force: bool,
     },
 }
 
@@ -467,6 +503,35 @@ async fn main() -> Result<()> {
                     .await?;
                 }
             },
+            ItemCommands::EnvVars { command } => match command {
+                EnvVarsCommands::Get { id, path } => {
+                    item::env_vars::get_env_vars(
+                        &config,
+                        cli.server.as_deref(),
+                        id.as_deref(),
+                        path.as_deref(),
+                        cli.format,
+                    )
+                    .await?;
+                }
+                EnvVarsCommands::Delete {
+                    name,
+                    id,
+                    path,
+                    force,
+                } => {
+                    item::env_vars::delete_env_var(
+                        &config,
+                        cli.server.as_deref(),
+                        id.as_deref(),
+                        path.as_deref(),
+                        &name,
+                        force,
+                        cli.format,
+                    )
+                    .await?;
+                }
+            },
         },
         Some(Commands::Task { command }) => match command {
             TaskCommands::List {
@@ -543,6 +608,35 @@ async fn main() -> Result<()> {
                         &config,
                         cli.server.as_deref(),
                         &id,
+                        cli.format,
+                    )
+                    .await?;
+                }
+            },
+            TaskCommands::EnvVars { command } => match command {
+                EnvVarsCommands::Get { id, path } => {
+                    item::env_vars::get_env_vars(
+                        &config,
+                        cli.server.as_deref(),
+                        id.as_deref(),
+                        path.as_deref(),
+                        cli.format,
+                    )
+                    .await?;
+                }
+                EnvVarsCommands::Delete {
+                    name,
+                    id,
+                    path,
+                    force,
+                } => {
+                    item::env_vars::delete_env_var(
+                        &config,
+                        cli.server.as_deref(),
+                        id.as_deref(),
+                        path.as_deref(),
+                        &name,
+                        force,
                         cli.format,
                     )
                     .await?;

--- a/tests/env_vars_test.rs
+++ b/tests/env_vars_test.rs
@@ -67,12 +67,14 @@ async fn test_get_env_vars_success() {
 #[tokio::test]
 async fn test_get_env_vars_unauthorized() {
     let mut server = Server::new_async().await;
+    let _key_mock = mock_valid_key(&mut server);
 
     let _m = server
         .mock(
             "GET",
             format!("/api/v0/content/{CONTENT_ID}/env-vars").as_str(),
         )
+        .match_header("authorization", "Key test_api_key")
         .with_status(401)
         .with_body(json!({"error": "Unauthorized"}).to_string())
         .create();
@@ -88,6 +90,7 @@ async fn test_get_env_vars_unauthorized() {
     .await;
 
     assert!(result.is_err());
+    _m.assert_async().await;
 }
 
 // --- delete ---
@@ -125,12 +128,14 @@ async fn test_delete_env_var_success() {
 #[tokio::test]
 async fn test_delete_env_var_not_found() {
     let mut server = Server::new_async().await;
+    let _key_mock = mock_valid_key(&mut server);
 
     let _m = server
         .mock(
             "DELETE",
             format!("/api/v0/content/{CONTENT_ID}/env-vars/MISSING").as_str(),
         )
+        .match_header("authorization", "Key test_api_key")
         .with_status(404)
         .with_body(json!({"error": "Variable not found"}).to_string())
         .create();
@@ -148,6 +153,7 @@ async fn test_delete_env_var_not_found() {
     .await;
 
     assert!(result.is_err());
+    _m.assert_async().await;
 }
 
 // --- set ---
@@ -193,6 +199,7 @@ async fn test_set_env_vars_success() {
 #[tokio::test]
 async fn test_set_env_vars_rejects_server_error() {
     let mut server = Server::new_async().await;
+    let _check_key_mock = mock_valid_key(&mut server);
 
     let _key_mock = server
         .mock("GET", "/api/v0/public-key")
@@ -205,6 +212,7 @@ async fn test_set_env_vars_rejects_server_error() {
             "PATCH",
             format!("/api/v0/content/{CONTENT_ID}/env-vars").as_str(),
         )
+        .match_header("authorization", "Key test_api_key")
         .with_status(400)
         .with_body(json!({"error": "name is unusable"}).to_string())
         .create();
@@ -221,6 +229,7 @@ async fn test_set_env_vars_rejects_server_error() {
     .await;
 
     assert!(result.is_err());
+    _set_mock.assert_async().await;
 }
 
 // --- replace ---
@@ -267,6 +276,7 @@ async fn test_replace_env_vars_success() {
 #[tokio::test]
 async fn test_replace_env_vars_not_found() {
     let mut server = Server::new_async().await;
+    let _check_key_mock = mock_valid_key(&mut server);
 
     let _key_mock = server
         .mock("GET", "/api/v0/public-key")
@@ -279,6 +289,7 @@ async fn test_replace_env_vars_not_found() {
             "PUT",
             format!("/api/v0/content/{CONTENT_ID}/env-vars").as_str(),
         )
+        .match_header("authorization", "Key test_api_key")
         .with_status(404)
         .with_body(json!({"error": "Content not found"}).to_string())
         .create();
@@ -296,4 +307,5 @@ async fn test_replace_env_vars_not_found() {
     .await;
 
     assert!(result.is_err());
+    _replace_mock.assert_async().await;
 }

--- a/tests/env_vars_test.rs
+++ b/tests/env_vars_test.rs
@@ -1,0 +1,299 @@
+use mockito::{Matcher, Server};
+use ricochet_cli::OutputFormat;
+use serde_json::json;
+use url::Url;
+
+const CONTENT_ID: &str = "01K66JV2Q123456789ABCDEF";
+
+// Test-only RSA public key, used to serve /api/v0/public-key so `set`/`replace`
+// can complete their encrypt-then-send flow. See src/crypto.rs for the tests
+// that verify encryption/decryption actually round-trips.
+const TEST_PUB_PEM: &str = "-----BEGIN RSA PUBLIC KEY-----
+MIIBCgKCAQEAr1XuDE4bFt7TnYqAtiRQ9RvC2sG3s8N8zUsCvhM+mZD7mGTN47bk
+vYxKvp5ShVnM/6XZeCfRQA2TKXnf6dWsRgcZcBMufKHfN9VLNxawLMKHddceHlLA
+rFTwsPE9rU9p5p5uA6zhUnZk/skzWumqZw9WK7Lztbh6fhX9UMYXvaBzCFF1nfTM
+kGl7YkRcwfL4p+1oa7uGFYaRxvBKv6q9/hm7W9Em7H0g4+icc85wkvlzJrghKakp
+5wDkaY8XmSGSiOZr0U8/fPBC4SASPuT5Hy17zZwu7SEYW31JYnRvFoo8bF8N3QxT
+WigXLNxbQJjhAq7Y6mU8h7yF2zWMbFGMqwIDAQAB
+-----END RSA PUBLIC KEY-----
+";
+
+fn test_config(server: &Server) -> ricochet_cli::config::Config {
+    ricochet_cli::config::Config::for_test(
+        Url::parse(&server.url()).unwrap(),
+        Some("test_api_key".to_string()),
+    )
+}
+
+// Every command runs a preflight check against this endpoint before doing
+// anything else.
+fn mock_valid_key(server: &mut Server) -> mockito::Mock {
+    server
+        .mock("GET", "/api/v0/check_key")
+        .with_status(200)
+        .create()
+}
+
+// --- get ---
+
+#[tokio::test]
+async fn test_get_env_vars_success() {
+    let mut server = Server::new_async().await;
+    let _key_mock = mock_valid_key(&mut server);
+
+    let _m = server
+        .mock(
+            "GET",
+            format!("/api/v0/content/{CONTENT_ID}/env-vars").as_str(),
+        )
+        .match_header("authorization", "Key test_api_key")
+        .with_status(200)
+        .with_body(json!(["DATABASE_URL", "API_KEY"]).to_string())
+        .create();
+
+    let config = test_config(&server);
+    let result = ricochet_cli::item::env_vars::get_env_vars(
+        &config,
+        None,
+        Some(CONTENT_ID),
+        None,
+        OutputFormat::Table,
+    )
+    .await;
+
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_get_env_vars_unauthorized() {
+    let mut server = Server::new_async().await;
+
+    let _m = server
+        .mock(
+            "GET",
+            format!("/api/v0/content/{CONTENT_ID}/env-vars").as_str(),
+        )
+        .with_status(401)
+        .with_body(json!({"error": "Unauthorized"}).to_string())
+        .create();
+
+    let config = test_config(&server);
+    let result = ricochet_cli::item::env_vars::get_env_vars(
+        &config,
+        None,
+        Some(CONTENT_ID),
+        None,
+        OutputFormat::Table,
+    )
+    .await;
+
+    assert!(result.is_err());
+}
+
+// --- delete ---
+
+#[tokio::test]
+async fn test_delete_env_var_success() {
+    let mut server = Server::new_async().await;
+    let _key_mock = mock_valid_key(&mut server);
+
+    let _m = server
+        .mock(
+            "DELETE",
+            format!("/api/v0/content/{CONTENT_ID}/env-vars/API_KEY").as_str(),
+        )
+        .match_header("authorization", "Key test_api_key")
+        .with_status(200)
+        .with_body(json!(["DATABASE_URL"]).to_string())
+        .create();
+
+    let config = test_config(&server);
+    let result = ricochet_cli::item::env_vars::delete_env_var(
+        &config,
+        None,
+        Some(CONTENT_ID),
+        None,
+        "API_KEY",
+        true,
+        OutputFormat::Table,
+    )
+    .await;
+
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_delete_env_var_not_found() {
+    let mut server = Server::new_async().await;
+
+    let _m = server
+        .mock(
+            "DELETE",
+            format!("/api/v0/content/{CONTENT_ID}/env-vars/MISSING").as_str(),
+        )
+        .with_status(404)
+        .with_body(json!({"error": "Variable not found"}).to_string())
+        .create();
+
+    let config = test_config(&server);
+    let result = ricochet_cli::item::env_vars::delete_env_var(
+        &config,
+        None,
+        Some(CONTENT_ID),
+        None,
+        "MISSING",
+        true,
+        OutputFormat::Table,
+    )
+    .await;
+
+    assert!(result.is_err());
+}
+
+// --- set ---
+
+#[tokio::test]
+async fn test_set_env_vars_success() {
+    let mut server = Server::new_async().await;
+    let _check_key_mock = mock_valid_key(&mut server);
+
+    let _key_mock = server
+        .mock("GET", "/api/v0/public-key")
+        .with_status(200)
+        .with_body(TEST_PUB_PEM)
+        .create();
+
+    let _set_mock = server
+        .mock(
+            "PATCH",
+            format!("/api/v0/content/{CONTENT_ID}/env-vars").as_str(),
+        )
+        .match_header("authorization", "Key test_api_key")
+        .match_body(Matcher::Any)
+        .with_status(200)
+        .with_body(json!(["DATABASE_URL", "API_KEY"]).to_string())
+        .create();
+
+    let config = test_config(&server);
+    let result = ricochet_cli::item::env_vars::set_env_vars(
+        &config,
+        None,
+        Some(CONTENT_ID),
+        None,
+        &["API_KEY=secret".to_string()],
+        OutputFormat::Table,
+    )
+    .await;
+
+    assert!(result.is_ok(), "expected success, got {result:?}");
+    _key_mock.assert_async().await;
+    _set_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_set_env_vars_rejects_server_error() {
+    let mut server = Server::new_async().await;
+
+    let _key_mock = server
+        .mock("GET", "/api/v0/public-key")
+        .with_status(200)
+        .with_body(TEST_PUB_PEM)
+        .create();
+
+    let _set_mock = server
+        .mock(
+            "PATCH",
+            format!("/api/v0/content/{CONTENT_ID}/env-vars").as_str(),
+        )
+        .with_status(400)
+        .with_body(json!({"error": "name is unusable"}).to_string())
+        .create();
+
+    let config = test_config(&server);
+    let result = ricochet_cli::item::env_vars::set_env_vars(
+        &config,
+        None,
+        Some(CONTENT_ID),
+        None,
+        &["BAD KEY=secret".to_string()],
+        OutputFormat::Table,
+    )
+    .await;
+
+    assert!(result.is_err());
+}
+
+// --- replace ---
+
+#[tokio::test]
+async fn test_replace_env_vars_success() {
+    let mut server = Server::new_async().await;
+    let _check_key_mock = mock_valid_key(&mut server);
+
+    let _key_mock = server
+        .mock("GET", "/api/v0/public-key")
+        .with_status(200)
+        .with_body(TEST_PUB_PEM)
+        .create();
+
+    let _replace_mock = server
+        .mock(
+            "PUT",
+            format!("/api/v0/content/{CONTENT_ID}/env-vars").as_str(),
+        )
+        .match_header("authorization", "Key test_api_key")
+        .match_body(Matcher::Any)
+        .with_status(200)
+        .with_body(json!(["DATABASE_URL"]).to_string())
+        .create();
+
+    let config = test_config(&server);
+    let result = ricochet_cli::item::env_vars::replace_env_vars(
+        &config,
+        None,
+        Some(CONTENT_ID),
+        None,
+        &["DATABASE_URL=postgres://localhost".to_string()],
+        true,
+        OutputFormat::Table,
+    )
+    .await;
+
+    assert!(result.is_ok(), "expected success, got {result:?}");
+    _key_mock.assert_async().await;
+    _replace_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_replace_env_vars_not_found() {
+    let mut server = Server::new_async().await;
+
+    let _key_mock = server
+        .mock("GET", "/api/v0/public-key")
+        .with_status(200)
+        .with_body(TEST_PUB_PEM)
+        .create();
+
+    let _replace_mock = server
+        .mock(
+            "PUT",
+            format!("/api/v0/content/{CONTENT_ID}/env-vars").as_str(),
+        )
+        .with_status(404)
+        .with_body(json!({"error": "Content not found"}).to_string())
+        .create();
+
+    let config = test_config(&server);
+    let result = ricochet_cli::item::env_vars::replace_env_vars(
+        &config,
+        None,
+        Some(CONTENT_ID),
+        None,
+        &["DATABASE_URL=postgres://localhost".to_string()],
+        true,
+        OutputFormat::Table,
+    )
+    .await;
+
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Closes #189 #190 #191 #192 

This PR adds support for our new env var endpoints as well as mocked tests to ensure that the CLI http request logic doesn't regress.