### PR TITLE
style(client): wrap the tar bundle path binding

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -204,7 +204,8 @@ impl RicochetClient {
 
         // Create a tar bundle from the directory
         pb.set_message("Creating bundle...");
-        let tar_path = std::env::temp_dir().join(format!("ricochet-{}.tar.gz", ulid::Ulid::generate()));
+        let tar_path =
+            std::env::temp_dir().join(format!("ricochet-{}.tar.gz", ulid::Ulid::generate()));
         crate::utils::create_bundle(path, &tar_path, include, exclude, extra_root_files, debug)?;
 
         // Get file size for progress tracking


### PR DESCRIPTION
The committed form of the `tar_path` binding in `src/client.rs` is 101 characters and does not match what `cargo fmt` produces.
Running `prek run -a` locally rewrites it, so the `cargo-fmt` hook fails on an otherwise clean tree.

CI does not catch this reliably.
The `rust-fmt` step runs `cargo fmt -q --all` and the `rust-lint` step runs `cargo fmt --all -- --check`, but both only `depends_on: cache`, so they run concurrently against the shared workspace.
Depending on which wins the race, the `--check` can observe a tree that `rust-fmt` has already reformatted.
That is worth tightening separately; this PR just makes the committed source match rustfmt.

## Changes

- `src/client.rs`: wrap the `let tar_path = ...` binding across two lines, as `cargo fmt` produces.

## Verification

- `cargo fmt --all --check` passes.
- `prek run -a` passes.

No behaviour change; this is formatting only.