### PR TITLE
fix(cli): keep json and yaml output parseable for invoke and settings update

### DIFF
--- a/src/item/invoke.rs
+++ b/src/item/invoke.rs
@@ -9,7 +9,7 @@ pub async fn invoke(
     id: &str,
     format: OutputFormat,
 ) -> Result<()> {
-    println!("Invoking task: {}", id.bright_cyan());
+    eprintln!("Invoking task: {}", id.bright_cyan());
 
     // Resolve server configuration
     let server_config = config.resolve_server(server_ref)?;
@@ -18,7 +18,7 @@ pub async fn invoke(
 
     match client.invoke(id, None).await {
         Ok(result) => {
-            println!("{} Task invoked successfully!\n", "✓".green().bold());
+            eprintln!("{} Task invoked successfully!\n", "✓".green().bold());
 
             match format {
                 OutputFormat::Json => {

--- a/src/item/settings.rs
+++ b/src/item/settings.rs
@@ -36,26 +36,29 @@ fn load_local(path: Option<&Path>) -> Result<(String, ContentItem)> {
     Ok((id, item))
 }
 
-/// Print the change list as a human-readable diff (remote → local).
-fn print_changes(id: &str, name: &str, changes: &[FieldChange]) {
-    println!(
-        "{} Local settings differ from {} ({})",
+/// Render the change list as a human-readable diff (remote → local).
+fn format_changes(id: &str, name: &str, changes: &[FieldChange]) -> String {
+    let header = format!(
+        "{} Local settings differ from {} ({})\n",
         "⚠".yellow().bold(),
         id.bright_cyan(),
         name
     );
-    println!();
     let width = changes.iter().map(|c| c.field.len()).max().unwrap_or(0);
-    for c in changes {
-        println!(
-            "  {:<width$}  {} {} {}",
-            c.field,
-            c.from.dimmed(),
-            "→".dimmed(),
-            c.to,
-            width = width
-        );
-    }
+    let rows: Vec<String> = changes
+        .iter()
+        .map(|c| {
+            format!(
+                "  {:<width$}  {} {} {}",
+                c.field,
+                c.from.dimmed(),
+                "→".dimmed(),
+                c.to,
+                width = width
+            )
+        })
+        .collect();
+    format!("{header}\n{}", rows.join("\n"))
 }
 
 /// Fetch the remote item and diff it against the local one.
@@ -378,7 +381,7 @@ pub async fn preview(
             if changes.is_empty() {
                 println!("{} Settings already up to date", "✓".green().bold());
             } else {
-                print_changes(&id, &local.content.name, &changes);
+                println!("{}", format_changes(&id, &local.content.name, &changes));
                 println!();
                 println!(
                     "Run {} to apply these changes.",
@@ -407,15 +410,15 @@ pub async fn update(
     let (changes, patch) = diff_against_remote(&client, &id, &local).await?;
 
     if changes.is_empty() {
-        println!("{} Settings already up to date", "✓".green().bold());
+        eprintln!("{} Settings already up to date", "✓".green().bold());
         return Ok(());
     }
 
-    print_changes(&id, &local.content.name, &changes);
-    println!();
+    eprintln!("{}", format_changes(&id, &local.content.name, &changes));
+    eprintln!();
 
     if !force && !utils::confirm("Apply these changes?")? {
-        println!("{}", "Update cancelled".yellow());
+        eprintln!("{}", "Update cancelled".yellow());
         return Ok(());
     }
 
@@ -530,5 +533,32 @@ packages = "renv.lock"
             })
         );
         assert_eq!(changes.len(), 2);
+    }
+
+    #[test]
+    fn format_changes_pads_the_field_column() {
+        colored::control::set_override(false);
+        let changes = vec![
+            FieldChange {
+                field: "access_type".to_string(),
+                from: "private".to_string(),
+                to: "external".to_string(),
+            },
+            FieldChange {
+                field: "serve.min_instances".to_string(),
+                from: "0".to_string(),
+                to: "3".to_string(),
+            },
+        ];
+        let rendered = format_changes("01KE52BY41EQ7NE89K7Z5MMZ84", "example-app", &changes);
+        let expected = [
+            "⚠ Local settings differ from 01KE52BY41EQ7NE89K7Z5MMZ84 (example-app)",
+            "",
+            "  access_type          private → external",
+            "  serve.min_instances  0 → 3",
+        ]
+        .join("\n");
+        assert_eq!(rendered, expected);
+        colored::control::unset_override();
     }
 }


### PR DESCRIPTION
Send status lines to stderr in `task invoke` and `settings update` so their `--format json|yaml` stdout parses.

<details>
<summary>Details</summary>

## Motivation

Follow-up to #193, which fixed this for the env-vars subcommands.
The same defect exists on two commands already on `main`: prose is written to stdout ahead of the machine-readable payload, so anything consuming the output has to strip a variable-length preamble first.

Reproduced against a stub server on `main` (`ce28af2`):

```console
$ ricochet task invoke 01K66JV2Q123456789ABCDEF --format json
Invoking task: 01K66JV2Q123456789ABCDEF
✓ Task invoked successfully!

{
  "invocation_id": "01INV0000000000000000000",
  ...
}
```

```console
$ ricochet app settings update -f --format json
⚠ Local settings differ from 01KE52BY41EQ7NE89K7Z5MMZ84 (example-app)

  content.access_type  private → external

{
  "content": {
    "access_type": "external"
  }
}
```

Both fail `json.load` on the first character.

## Changes

### `src/item/invoke.rs`

`Invoking task: <id>` and `✓ Task invoked successfully!` move from `println!` to `eprintln!`.

### `src/item/settings.rs`

In `update`, the human diff, the "Settings already up to date" notice and the "Update cancelled" notice move to stderr.
On that command they are the preamble to a confirmation prompt, not output.

`print_changes` becomes `format_changes` and returns the rendered diff rather than printing it.
That is what lets the two callers differ: `preview` keeps writing it to stdout, where in table mode it is the command's actual output, while `update` writes it to stderr.
Making it a pure function also made it testable, so it now has one (`format_changes_pads_the_field_column`).

## Behaviour change

Table output is unchanged on a terminal, where stdout and stderr both land on the tty.
It changes for anyone redirecting only stdout to a file in table mode: the status lines now follow stderr.
That is the intended trade, and it matches what #193 did.

`settings preview` is untouched, including in table mode.

## Not included

`settings update` with `--format json` still writes nothing to stdout when there are no changes, or when the confirmation is declined.
Those paths return before the `match format`.
Emitting a patch that was never applied would be worse, so this leaves the no-op contract alone. Happy to define one if you'd prefer `{}`.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` clean
- full test suite green (77 lib + all integration suites)
- `just docs-check` up to date, `prek run -a` passing
- both commands re-run against the stub server: stdout parses via `json.load` / `yaml.safe_load`, status lines confirmed on stderr, table mode visually unchanged

</details>

Instructions-PR: none