### PR TITLE
ci(lint): drop the rust-fmt step that races the format check

### DIFF
--- a/.crow/lint.yaml
+++ b/.crow/lint.yaml
@@ -41,16 +41,6 @@ steps:
           path: backblaze/tokens/cicd
           key: applicationKey
 
-  rust-fmt:
-    image: reg.ricochet.rs/docker.io/library/rust:1.97
-    depends_on: cache
-    commands:
-      - export PATH=".sccache-cache:$PATH"
-      - . ./.sccache
-      - rustup component add rustfmt
-      - cargo fmt -q --all
-      - sccache --show-stats
-
   rust-lint:
     image: reg.ricochet.rs/docker.io/library/rust:1.97
     depends_on: cache


### PR DESCRIPTION
The `rust-fmt` step ran `cargo fmt -q --all`, mutating the shared workspace, while `rust-lint` ran `cargo fmt --all -- --check` against that same workspace.
Both only declared `depends_on: cache`, so they ran concurrently and the check frequently observed a tree that `rust-fmt` had already reformatted.
The result is that `cargo fmt --all -- --check` silently passed on unformatted source.

This is not theoretical.
`src/client.rs` carried a 101-character line that `cargo fmt` rewrites, and `ci/crow/push/lint` passed on `a6bed5b`, `3c3beba` and `af14c67` while it was there.
It took a local `prek run -a` to surface it, fixed in #194.

`rust-fmt` predates the format check.
It was added in `1c6db5b`, when `rust-lint` did not verify formatting at all, and `44b4603` (#92) later added `cargo fmt --all -- --check` to `rust-lint` without removing it.
Nothing commits or pushes the reformatted tree, so since #92 the step has only ever masked the check.

## Changes

- `.crow/lint.yaml`: remove the `rust-fmt` step. `rust-lint` keeps the authoritative `cargo fmt --all -- --check`.

No step declared `depends_on: rust-fmt`, so the step DAG is otherwise unchanged.
The `SKIP: cargo-fmt` comment in the `prek` step already points at `rust-lint` as the real check, so it stays accurate.

## Verification

- `crow lint .crow/` reports all six configs valid.
- `prek run -a` passes.
- I will push a temporary commit with a deliberately misformatted line to confirm `rust-lint` now fails on it, then drop that commit before merge.