### PR TITLE
test: serialize every test that mutates process environment

### DIFF
--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -1,5 +1,6 @@
 use mockito::Server;
 use ricochet_cli::config::Config;
+use serial_test::serial;
 use std::env;
 use tempfile::TempDir;
 use url::Url;
@@ -20,6 +21,7 @@ fn cleanup_env() {
 }
 
 #[tokio::test]
+#[serial(env_tests)]
 async fn test_client_creation_with_valid_key() {
     cleanup_env();
     let mut server = Server::new_async().await;
@@ -50,6 +52,7 @@ async fn test_client_creation_with_valid_key() {
 }
 
 #[tokio::test]
+#[serial(env_tests)]
 async fn test_client_with_invalid_server() -> anyhow::Result<()> {
     cleanup_env();
 
@@ -124,6 +127,7 @@ async fn test_api_key_format() {
 }
 
 #[test]
+#[serial(env_tests)]
 fn test_config_persistence() {
     let (_config, temp_dir) = create_test_config();
 

--- a/tests/server_test.rs
+++ b/tests/server_test.rs
@@ -74,6 +74,7 @@ mod servers_tests {
     // ==================== Config add_server tests ====================
 
     #[test]
+    #[serial(env_tests)]
     fn test_add_server_to_empty_config() {
         cleanup_env();
         let _temp_dir = setup_test_env();
@@ -103,6 +104,7 @@ mod servers_tests {
     }
 
     #[test]
+    #[serial(env_tests)]
     fn test_add_server_with_api_key() {
         cleanup_env();
         let _temp_dir = setup_test_env();
@@ -124,6 +126,7 @@ mod servers_tests {
     }
 
     #[test]
+    #[serial(env_tests)]
     fn test_add_multiple_servers() {
         cleanup_env();
         let _temp_dir = setup_test_env();
@@ -168,6 +171,7 @@ mod servers_tests {
     // ==================== Config remove_server tests ====================
 
     #[test]
+    #[serial(env_tests)]
     fn test_remove_non_default_server() {
         cleanup_env();
         let _temp_dir = setup_test_env();
@@ -186,6 +190,7 @@ mod servers_tests {
     }
 
     #[test]
+    #[serial(env_tests)]
     fn test_remove_default_server_clears_default() {
         cleanup_env();
         let _temp_dir = setup_test_env();
@@ -203,6 +208,7 @@ mod servers_tests {
     }
 
     #[test]
+    #[serial(env_tests)]
     fn test_remove_nonexistent_server_fails() {
         cleanup_env();
         let _temp_dir = setup_test_env();
@@ -220,6 +226,7 @@ mod servers_tests {
     // ==================== Config set_default_server tests ====================
 
     #[test]
+    #[serial(env_tests)]
     fn test_set_default_server() {
         cleanup_env();
         let _temp_dir = setup_test_env();
@@ -235,6 +242,7 @@ mod servers_tests {
     }
 
     #[test]
+    #[serial(env_tests)]
     fn test_set_default_server_nonexistent_fails() {
         cleanup_env();
         let _temp_dir = setup_test_env();
@@ -252,6 +260,7 @@ mod servers_tests {
     // ==================== Config list_servers tests ====================
 
     #[test]
+    #[serial(env_tests)]
     fn test_list_servers_returns_all() {
         cleanup_env();
         let _temp_dir = setup_test_env();
@@ -271,6 +280,7 @@ mod servers_tests {
     }
 
     #[test]
+    #[serial(env_tests)]
     fn test_list_servers_includes_api_key_status() {
         cleanup_env();
         let _temp_dir = setup_test_env();
@@ -329,6 +339,7 @@ mod servers_tests {
     }
 
     #[test]
+    #[serial(env_tests)]
     fn test_resolve_server_by_url_unknown() {
         cleanup_env();
         let _temp_dir = setup_test_env();
@@ -454,6 +465,7 @@ mod servers_tests {
     // ==================== default server resolution tests ====================
 
     #[test]
+    #[serial(env_tests)]
     fn test_resolve_default_server() {
         cleanup_env();
         let _temp_dir = setup_test_env();
@@ -468,6 +480,7 @@ mod servers_tests {
     }
 
     #[test]
+    #[serial(env_tests)]
     fn test_resolve_default_server_fallback() {
         cleanup_env();
         let _temp_dir = setup_test_env();
@@ -483,6 +496,7 @@ mod servers_tests {
     }
 
     #[test]
+    #[serial(env_tests)]
     fn test_resolve_default_server_no_servers() {
         cleanup_env();
         let _temp_dir = setup_test_env();
@@ -511,6 +525,7 @@ mod servers_tests {
     // ==================== Backward compatibility tests ====================
 
     #[test]
+    #[serial(env_tests)]
     fn test_server_url_uses_default() {
         cleanup_env();
         let _temp_dir = setup_test_env();
@@ -525,6 +540,7 @@ mod servers_tests {
     }
 
     #[test]
+    #[serial(env_tests)]
     fn test_api_key_uses_default() {
         cleanup_env();
         let _temp_dir = setup_test_env();
@@ -539,6 +555,7 @@ mod servers_tests {
     }
 
     #[test]
+    #[serial(env_tests)]
     fn test_api_key_error_when_no_key() {
         cleanup_env();
         let _temp_dir = setup_test_env();


### PR DESCRIPTION
`serial_test`'s `env_tests` group only serializes its own members.
Tests that called `cleanup_env()`, which does `remove_var("RICOCHET_API_KEY")` and `remove_var("RICOCHET_SERVER")`, were not in the group.
They therefore ran concurrently with the two group members that set those variables, and cleared them between the `set_var` and the read.

The failure is intermittent and presents as the config value winning over the environment override:

```
---- servers_tests::test_resolve_server_api_key_env_override stdout ----
assertion `left == right` failed
  left: Some("rico_prod_key")
 right: Some("rico_env_override_key")
```

This fails CI on unchanged commits.
Pipelines [891](https://ci.ricochet.rs/repos/4/pipeline/891/2) and [893](https://ci.ricochet.rs/repos/4/pipeline/893/2) ran the identical tree of #196 and disagreed, which is currently blocking that PR.
`.crow/test.yaml` runs `cargo test -q --all-features --workspace` without `--test-threads=1`, so CI is exposed to it.

## Changes

- `tests/server_test.rs`: add `#[serial(env_tests)]` to the 17 tests that call `cleanup_env()`.
- `tests/auth_integration.rs`: add `#[serial(env_tests)]` to the 3 tests that call `cleanup_env()` or set `HOME`, and import `serial_test::serial`.

`src/config.rs` also calls `cleanup_env()` from unserialized tests, but no test in the lib test binary sets `RICOCHET_SERVER` or `RICOCHET_API_KEY`, so the removals there are idempotent and cannot race. Left alone.

## Verification

Stress run of the `server_test` binary at `--test-threads=16` under six busy-loop CPU hogs:

- before: 1 failure in 60 runs (`test_resolve_server_env_var_overrides_arg`)
- after: 0 failures in 120 runs

`cargo test -q --all-features --workspace` and `prek run -a` both pass.