### PR TITLE
chore: enable shared agent instructions

### DIFF
--- a/.crow/instructions.yaml
+++ b/.crow/instructions.yaml
@@ -1,0 +1,37 @@
+when:
+  - event: pull_request
+  - event: pull_request_edited
+  - event: push
+    branch:
+      - ${CI_REPO_DEFAULT_BRANCH}
+
+labels:
+  agent: thumper
+
+steps:
+  paired-pr:
+    when:
+      - event: pull_request
+      - event: pull_request_edited
+    image: reg.ricochet.rs/docker.io/library/alpine:3.24
+    environment:
+      GH_TOKEN:
+        from_secret: agent_instructions_token
+    commands:
+      - apk add -q --no-cache github-cli jq
+      - gh repo clone ricochet-rs/agent-instructions /tmp/agent-instructions -- --depth=1
+      - /tmp/agent-instructions/scripts/paired-instructions-pr.sh check "$${CI_REPO}" "$${CI_COMMIT_PULL_REQUEST}"
+
+  merge-paired-pr:
+    when:
+      - event: push
+        branch:
+          - ${CI_REPO_DEFAULT_BRANCH}
+    image: reg.ricochet.rs/docker.io/library/alpine:3.24
+    environment:
+      GH_TOKEN:
+        from_secret: agent_instructions_token
+    commands:
+      - apk add -q --no-cache github-cli jq
+      - gh repo clone ricochet-rs/agent-instructions /tmp/agent-instructions -- --depth=1
+      - /tmp/agent-instructions/scripts/paired-instructions-pr.sh merge-for-commit "$${CI_REPO}" "$${CI_COMMIT_SHA}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Codex instructions
+
+Before doing any work, read `CLAUDE.md` completely and follow it.
+If `CLAUDE.md` cannot be read, stop and report the failure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,23 @@
-# CLAUDE.md
+# Required Ricochet instructions
+
+Before inspecting repository files, planning, editing, or running project commands, ensure the shared instructions are available.
+
+1. Use `~/.cache/ricochet-rs/agent-instructions` as the shared checkout.
+2. If the checkout is absent, clone `git@github.com:ricochet-rs/agent-instructions.git` there.
+3. Fetch `origin/main` and check it out in detached-HEAD mode.
+4. Verify that cached `HEAD` exactly matches `origin/main`.
+5. Verify that `instructions/global.md`, `.codex-plugin/plugin.json`, and every selected `SKILL.md` exist.
+6. Read `instructions/global.md`.
+7. Read and follow `skills/development-flow/SKILL.md` for code changes.
+8. Read the applicable language skills according to the repository manifests and files involved.
+
+The shared skills may not appear in the startup skill catalog.
+Read their `SKILL.md` files directly from the shared checkout and follow them for the current session.
+
+If authentication, synchronization, HEAD validation, or a required read fails, stop before modifying the repository and report the failure clearly.
+Do not silently continue with missing or stale shared instructions.
+
+## Repository instructions
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 


### PR DESCRIPTION
This repository now loads current Ricochet organization guidance and enforces the paired-instructions lifecycle in CI.

<details>
<summary>AI Summary</summary>

This change adds the repository-neutral bootstrap for Codex and Claude while preserving existing repository-specific instructions.

The CI entry point clones `ricochet-rs/agent-instructions` from shared `main` at runtime and delegates validation and post-merge handling to the centralized checker.
Future checker fixes therefore land once in the shared repository rather than being copied across consumers.

Validation:

- Repository pre-commit hooks when configured
- CI configuration parsing or `crow lint`
- `git diff --check`

</details>

Instructions-PR: none
