### PR TITLE
feat: add ricochet user credentials command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,8 +2320,8 @@ dependencies = [
 
 [[package]]
 name = "ricochet-core"
-version = "0.15.0"
-source = "git+https://github.com/ricochet-rs/ricochet#40d3737931fd1feec88acfc53651bd42704074c1"
+version = "0.16.0"
+source = "git+https://github.com/ricochet-rs/ricochet#d98cdd447b1e95a88312f72e22ec799497b19977"
 dependencies = [
  "anyhow",
  "bytesize",

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -46,6 +46,8 @@ This document contains the help content for the `ricochet` command-line program.
 * [`ricochet server add`↴](#ricochet-server-add)
 * [`ricochet server remove`↴](#ricochet-server-remove)
 * [`ricochet server set-default`↴](#ricochet-server-set-default)
+* [`ricochet user`↴](#ricochet-user)
+* [`ricochet user credentials`↴](#ricochet-user-credentials)
 * [`ricochet self`↴](#ricochet-self)
 * [`ricochet self update`↴](#ricochet-self-update)
 
@@ -66,6 +68,7 @@ Ricochet CLI
 * `app` — Manage deployed app items
 * `task` — Manage deployed task items
 * `server` — Manage configured Ricochet servers
+* `user` — Manage the current user's account
 * `self` — Manage the ricochet CLI itself
 
 ###### **Options:**
@@ -696,6 +699,34 @@ Set the default server
 ###### **Arguments:**
 
 * `<NAME>` — Server name to set as default
+
+
+
+## `ricochet user`
+
+Manage the current user's account
+
+**Usage:** `ricochet user <COMMAND>`
+
+###### **Subcommands:**
+
+* `credentials` — List Git credentials
+
+
+
+## `ricochet user credentials`
+
+List Git credentials
+
+**Usage:** `ricochet user credentials [OPTIONS]`
+
+###### **Options:**
+
+* `--user-id <USER_ID>` — Filter by user ID (admins only)
+* `--type <TYPE>` — Filter by credential type
+
+  Possible values: `ssh`, `https`
+
 
 
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,7 +2,10 @@ use crate::config::{ServerConfig, parse_server_url};
 use anyhow::{Context, Result};
 use colored::Colorize;
 use reqwest::{Client, Response, StatusCode};
-use ricochet_core::content::ContentItem;
+use ricochet_core::{
+    config::git::{GitCredential, GitProtocol},
+    content::ContentItem,
+};
 use serde::de::DeserializeOwned;
 use serde_json::json;
 use std::{
@@ -527,6 +530,35 @@ impl RicochetClient {
             .json(encrypted)
             .send()
             .await?;
+        Self::handle_response(response).await
+    }
+
+    /// List Git credentials owned by the current user, or by `user_id` if
+    /// the caller is an admin. Credential values are never returned.
+    pub async fn list_credentials(
+        &self,
+        user_id: Option<&str>,
+        protocol: Option<GitProtocol>,
+    ) -> Result<Vec<GitCredential>> {
+        let mut url = self.base_url.clone();
+        url.set_path("/api/v0/user/credentials");
+        {
+            let mut pairs = url.query_pairs_mut();
+            if let Some(uid) = user_id {
+                pairs.append_pair("user_id", uid);
+            }
+            if let Some(p) = protocol {
+                pairs.append_pair("type", &p.to_string());
+            }
+        }
+
+        let response = self
+            .client
+            .get(url)
+            .header("Authorization", format!("Key {}", self.api_key))
+            .send()
+            .await?;
+
         Self::handle_response(response).await
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -533,8 +533,8 @@ impl RicochetClient {
         Self::handle_response(response).await
     }
 
-    /// List Git credentials owned by the current user, or by `user_id` if
-    /// the caller is an admin. Credential values are never returned.
+    /// List Git credentials owned by the current user, or by `user_id` if the caller is an admin.
+    /// Credential values are never returned.
     pub async fn list_credentials(
         &self,
         user_id: Option<&str>,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,3 +6,4 @@ pub mod init;
 pub mod list;
 pub mod server;
 pub mod update;
+pub mod user;

--- a/src/commands/user.rs
+++ b/src/commands/user.rs
@@ -1,0 +1,53 @@
+use crate::{OutputFormat, client::RicochetClient, config::Config};
+use anyhow::Result;
+use colored::Colorize;
+use comfy_table::{Table, presets::UTF8_FULL};
+use ricochet_core::config::git::GitProtocol;
+
+pub async fn list_credentials(
+    config: &Config,
+    server_ref: Option<&str>,
+    user_id: Option<&str>,
+    protocol: Option<GitProtocol>,
+    format: OutputFormat,
+) -> Result<()> {
+    let server_config = config.resolve_server(server_ref)?;
+    let client = RicochetClient::new(&server_config)?;
+    client.preflight_key_check().await?;
+
+    let credentials = client.list_credentials(user_id, protocol).await?;
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&credentials)?);
+        }
+        OutputFormat::Yaml => {
+            println!("{}", serde_yaml::to_string(&credentials)?);
+        }
+        OutputFormat::Table => {
+            println!("{}", server_config.url.as_str().italic().dimmed());
+
+            if credentials.is_empty() {
+                println!("{}", "No credentials found.".yellow());
+                return Ok(());
+            }
+
+            let mut table = Table::new();
+            table.load_style(UTF8_FULL);
+            table.set_header(vec!["ID", "Name", "Type", "User ID"]);
+            for cred in &credentials {
+                table.add_row(vec![
+                    cred.id.as_str(),
+                    cred.name.as_str(),
+                    &cred.protocol.to_string(),
+                    cred.user_id.as_str(),
+                ]);
+            }
+
+            println!("{}", table);
+            println!("\n{} credential(s)", credentials.len());
+        }
+    }
+
+    Ok(())
+}

--- a/src/commands/user.rs
+++ b/src/commands/user.rs
@@ -2,7 +2,41 @@ use crate::{OutputFormat, client::RicochetClient, config::Config};
 use anyhow::Result;
 use colored::Colorize;
 use comfy_table::{Table, presets::UTF8_FULL};
-use ricochet_core::config::git::GitProtocol;
+use ricochet_core::config::git::{GitCredential, GitProtocol};
+
+fn format_credentials(
+    server_url: &str,
+    credentials: &[GitCredential],
+    format: OutputFormat,
+) -> Result<String> {
+    match format {
+        OutputFormat::Json => Ok(serde_json::to_string_pretty(credentials)?),
+        OutputFormat::Yaml => Ok(serde_yaml::to_string(credentials)?),
+        OutputFormat::Table => {
+            let mut output = server_url.italic().dimmed().to_string();
+
+            if credentials.is_empty() {
+                output.push_str(&format!("\n{}", "No credentials found.".yellow()));
+                return Ok(output);
+            }
+
+            let mut table = Table::new();
+            table.load_style(UTF8_FULL);
+            table.set_header(vec!["ID", "Name", "Type", "User ID"]);
+            for credential in credentials {
+                table.add_row(vec![
+                    credential.id.as_str(),
+                    credential.name.as_str(),
+                    &credential.protocol.to_string(),
+                    credential.user_id.as_str(),
+                ]);
+            }
+
+            output.push_str(&format!("\n{table}\n\n{} credential(s)", credentials.len()));
+            Ok(output)
+        }
+    }
+}
 
 pub async fn list_credentials(
     config: &Config,
@@ -17,37 +51,78 @@ pub async fn list_credentials(
 
     let credentials = client.list_credentials(user_id, protocol).await?;
 
-    match format {
-        OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(&credentials)?);
-        }
-        OutputFormat::Yaml => {
-            println!("{}", serde_yaml::to_string(&credentials)?);
-        }
-        OutputFormat::Table => {
-            println!("{}", server_config.url.as_str().italic().dimmed());
+    println!(
+        "{}",
+        format_credentials(server_config.url.as_str(), &credentials, format)?
+    );
 
-            if credentials.is_empty() {
-                println!("{}", "No credentials found.".yellow());
-                return Ok(());
-            }
+    Ok(())
+}
 
-            let mut table = Table::new();
-            table.load_style(UTF8_FULL);
-            table.set_header(vec!["ID", "Name", "Type", "User ID"]);
-            for cred in &credentials {
-                table.add_row(vec![
-                    cred.id.as_str(),
-                    cred.name.as_str(),
-                    &cred.protocol.to_string(),
-                    cred.user_id.as_str(),
-                ]);
-            }
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-            println!("{}", table);
-            println!("\n{} credential(s)", credentials.len());
+    fn credential(protocol: GitProtocol) -> GitCredential {
+        GitCredential {
+            id: "credential-id".to_string(),
+            user_id: "user-id".to_string(),
+            name: "deploy-key".to_string(),
+            protocol,
         }
     }
 
-    Ok(())
+    #[test]
+    fn formats_json_output() -> Result<()> {
+        let output = format_credentials(
+            "https://example.com",
+            &[credential(GitProtocol::Ssh)],
+            OutputFormat::Json,
+        )?;
+        let parsed: Vec<GitCredential> = serde_json::from_str(&output)?;
+
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].id, "credential-id");
+        assert_eq!(parsed[0].protocol, GitProtocol::Ssh);
+        Ok(())
+    }
+
+    #[test]
+    fn formats_yaml_output() -> Result<()> {
+        let output = format_credentials(
+            "https://example.com",
+            &[credential(GitProtocol::Https)],
+            OutputFormat::Yaml,
+        )?;
+        let parsed: Vec<GitCredential> = serde_yaml::from_str(&output)?;
+
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].protocol, GitProtocol::Https);
+        Ok(())
+    }
+
+    #[test]
+    fn formats_table_output() -> Result<()> {
+        let output = format_credentials(
+            "https://example.com",
+            &[credential(GitProtocol::Ssh)],
+            OutputFormat::Table,
+        )?;
+
+        assert!(output.contains("https://example.com"));
+        assert!(output.contains("credential-id"));
+        assert!(output.contains("deploy-key"));
+        assert!(output.contains("ssh"));
+        assert!(output.contains("user-id"));
+        assert!(output.contains("1 credential(s)"));
+        Ok(())
+    }
+
+    #[test]
+    fn formats_empty_table_output() -> Result<()> {
+        let output = format_credentials("https://example.com", &[], OutputFormat::Table)?;
+
+        assert!(output.contains("No credentials found."));
+        Ok(())
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,6 +119,11 @@ enum Commands {
         #[command(subcommand)]
         command: ServerCommands,
     },
+    /// Manage the current user's account
+    User {
+        #[command(subcommand)]
+        command: UserCommands,
+    },
     /// Update the ricochet CLI to the latest version
     #[command(hide = true)]
     SelfUpdate {
@@ -372,6 +377,34 @@ enum ServerCommands {
         /// Server name to set as default
         name: String,
     },
+}
+
+#[derive(Subcommand)]
+enum UserCommands {
+    /// List Git credentials
+    Credentials {
+        /// Filter by user ID (admins only)
+        #[arg(long)]
+        user_id: Option<String>,
+        /// Filter by credential type
+        #[arg(long, value_enum)]
+        r#type: Option<CredentialType>,
+    },
+}
+
+#[derive(clap::ValueEnum, Clone, Copy, Debug)]
+enum CredentialType {
+    Ssh,
+    Https,
+}
+
+impl From<CredentialType> for ricochet_core::config::git::GitProtocol {
+    fn from(value: CredentialType) -> Self {
+        match value {
+            CredentialType::Ssh => ricochet_core::config::git::GitProtocol::Ssh,
+            CredentialType::Https => ricochet_core::config::git::GitProtocol::Https,
+        }
+    }
 }
 
 #[derive(Subcommand)]
@@ -741,6 +774,18 @@ async fn main() -> Result<()> {
             }
             ServerCommands::SetDefault { name } => {
                 commands::server::set_default(&mut config, name)?;
+            }
+        },
+        Some(Commands::User { command }) => match command {
+            UserCommands::Credentials { user_id, r#type } => {
+                commands::user::list_credentials(
+                    &config,
+                    cli.server.as_deref(),
+                    user_id.as_deref(),
+                    r#type.map(Into::into),
+                    cli.format,
+                )
+                .await?;
             }
         },
         Some(Commands::SelfUpdate { force, dry_run }) => {

--- a/tests/user_credentials_test.rs
+++ b/tests/user_credentials_test.rs
@@ -3,11 +3,11 @@ use ricochet_cli::OutputFormat;
 use serde_json::json;
 use url::Url;
 
-fn test_config(server: &Server) -> ricochet_cli::config::Config {
-    ricochet_cli::config::Config::for_test(
-        Url::parse(&server.url()).unwrap(),
+fn test_config(server: &Server) -> anyhow::Result<ricochet_cli::config::Config> {
+    Ok(ricochet_cli::config::Config::for_test(
+        Url::parse(&server.url())?,
         Some("test_api_key".to_string()),
-    )
+    ))
 }
 
 // Every command runs a preflight check against this endpoint before doing
@@ -20,7 +20,7 @@ fn mock_valid_key(server: &mut Server) -> mockito::Mock {
 }
 
 #[tokio::test]
-async fn test_list_credentials_success() {
+async fn test_list_credentials_success() -> anyhow::Result<()> {
     let mut server = Server::new_async().await;
     let _key_mock = mock_valid_key(&mut server);
 
@@ -48,7 +48,7 @@ async fn test_list_credentials_success() {
         )
         .create();
 
-    let config = test_config(&server);
+    let config = test_config(&server)?;
     let result = ricochet_cli::commands::user::list_credentials(
         &config,
         None,
@@ -59,10 +59,11 @@ async fn test_list_credentials_success() {
     .await;
 
     assert!(result.is_ok(), "expected success, got {result:?}");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_list_credentials_json_format() {
+async fn test_list_credentials_json_format() -> anyhow::Result<()> {
     let mut server = Server::new_async().await;
     let _key_mock = mock_valid_key(&mut server);
 
@@ -83,7 +84,7 @@ async fn test_list_credentials_json_format() {
         )
         .create();
 
-    let config = test_config(&server);
+    let config = test_config(&server)?;
     let result = ricochet_cli::commands::user::list_credentials(
         &config,
         None,
@@ -94,10 +95,11 @@ async fn test_list_credentials_json_format() {
     .await;
 
     assert!(result.is_ok(), "expected success, got {result:?}");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_list_credentials_with_filters() {
+async fn test_list_credentials_with_filters() -> anyhow::Result<()> {
     let mut server = Server::new_async().await;
     let _key_mock = mock_valid_key(&mut server);
 
@@ -121,7 +123,7 @@ async fn test_list_credentials_with_filters() {
         )
         .create();
 
-    let config = test_config(&server);
+    let config = test_config(&server)?;
     let result = ricochet_cli::commands::user::list_credentials(
         &config,
         None,
@@ -133,10 +135,11 @@ async fn test_list_credentials_with_filters() {
 
     assert!(result.is_ok(), "expected success, got {result:?}");
     _m.assert_async().await;
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_list_credentials_empty_response() {
+async fn test_list_credentials_empty_response() -> anyhow::Result<()> {
     let mut server = Server::new_async().await;
     let _key_mock = mock_valid_key(&mut server);
 
@@ -147,7 +150,7 @@ async fn test_list_credentials_empty_response() {
         .with_body(json!([]).to_string())
         .create();
 
-    let config = test_config(&server);
+    let config = test_config(&server)?;
     let result = ricochet_cli::commands::user::list_credentials(
         &config,
         None,
@@ -158,10 +161,11 @@ async fn test_list_credentials_empty_response() {
     .await;
 
     assert!(result.is_ok(), "expected success, got {result:?}");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_list_credentials_forbidden() {
+async fn test_list_credentials_forbidden() -> anyhow::Result<()> {
     let mut server = Server::new_async().await;
     let _key_mock = mock_valid_key(&mut server);
 
@@ -172,7 +176,7 @@ async fn test_list_credentials_forbidden() {
         .with_body(json!({"error": "Insufficient privileges"}).to_string())
         .create();
 
-    let config = test_config(&server);
+    let config = test_config(&server)?;
     let result = ricochet_cli::commands::user::list_credentials(
         &config,
         None,
@@ -184,4 +188,5 @@ async fn test_list_credentials_forbidden() {
 
     assert!(result.is_err());
     _m.assert_async().await;
+    Ok(())
 }

--- a/tests/user_credentials_test.rs
+++ b/tests/user_credentials_test.rs
@@ -1,0 +1,187 @@
+use mockito::{Matcher, Server};
+use ricochet_cli::OutputFormat;
+use serde_json::json;
+use url::Url;
+
+fn test_config(server: &Server) -> ricochet_cli::config::Config {
+    ricochet_cli::config::Config::for_test(
+        Url::parse(&server.url()).unwrap(),
+        Some("test_api_key".to_string()),
+    )
+}
+
+// Every command runs a preflight check against this endpoint before doing
+// anything else.
+fn mock_valid_key(server: &mut Server) -> mockito::Mock {
+    server
+        .mock("GET", "/api/v0/check_key")
+        .with_status(200)
+        .create()
+}
+
+#[tokio::test]
+async fn test_list_credentials_success() {
+    let mut server = Server::new_async().await;
+    let _key_mock = mock_valid_key(&mut server);
+
+    let _m = server
+        .mock("GET", "/api/v0/user/credentials")
+        .match_query(Matcher::Missing)
+        .match_header("authorization", "Key test_api_key")
+        .with_status(200)
+        .with_body(
+            json!([
+                {
+                    "id": "01K66JV2Q123456789ABCDEF",
+                    "user_id": "user_1",
+                    "name": "deploy-key",
+                    "type": "ssh"
+                },
+                {
+                    "id": "01K66JV2Q987654321FEDCBA",
+                    "user_id": "user_1",
+                    "name": "https-token",
+                    "type": "https"
+                }
+            ])
+            .to_string(),
+        )
+        .create();
+
+    let config = test_config(&server);
+    let result = ricochet_cli::commands::user::list_credentials(
+        &config,
+        None,
+        None,
+        None,
+        OutputFormat::Table,
+    )
+    .await;
+
+    assert!(result.is_ok(), "expected success, got {result:?}");
+}
+
+#[tokio::test]
+async fn test_list_credentials_json_format() {
+    let mut server = Server::new_async().await;
+    let _key_mock = mock_valid_key(&mut server);
+
+    let _m = server
+        .mock("GET", "/api/v0/user/credentials")
+        .match_query(Matcher::Missing)
+        .with_status(200)
+        .with_body(
+            json!([
+                {
+                    "id": "01K66JV2Q123456789ABCDEF",
+                    "user_id": "user_1",
+                    "name": "deploy-key",
+                    "type": "ssh"
+                }
+            ])
+            .to_string(),
+        )
+        .create();
+
+    let config = test_config(&server);
+    let result = ricochet_cli::commands::user::list_credentials(
+        &config,
+        None,
+        None,
+        None,
+        OutputFormat::Json,
+    )
+    .await;
+
+    assert!(result.is_ok(), "expected success, got {result:?}");
+}
+
+#[tokio::test]
+async fn test_list_credentials_with_filters() {
+    let mut server = Server::new_async().await;
+    let _key_mock = mock_valid_key(&mut server);
+
+    let _m = server
+        .mock("GET", "/api/v0/user/credentials")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("user_id".into(), "user_2".into()),
+            Matcher::UrlEncoded("type".into(), "ssh".into()),
+        ]))
+        .with_status(200)
+        .with_body(
+            json!([
+                {
+                    "id": "01K66JV2Q123456789ABCDEF",
+                    "user_id": "user_2",
+                    "name": "deploy-key",
+                    "type": "ssh"
+                }
+            ])
+            .to_string(),
+        )
+        .create();
+
+    let config = test_config(&server);
+    let result = ricochet_cli::commands::user::list_credentials(
+        &config,
+        None,
+        Some("user_2"),
+        Some(ricochet_core::config::git::GitProtocol::Ssh),
+        OutputFormat::Table,
+    )
+    .await;
+
+    assert!(result.is_ok(), "expected success, got {result:?}");
+    _m.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_list_credentials_empty_response() {
+    let mut server = Server::new_async().await;
+    let _key_mock = mock_valid_key(&mut server);
+
+    let _m = server
+        .mock("GET", "/api/v0/user/credentials")
+        .match_query(Matcher::Missing)
+        .with_status(200)
+        .with_body(json!([]).to_string())
+        .create();
+
+    let config = test_config(&server);
+    let result = ricochet_cli::commands::user::list_credentials(
+        &config,
+        None,
+        None,
+        None,
+        OutputFormat::Table,
+    )
+    .await;
+
+    assert!(result.is_ok(), "expected success, got {result:?}");
+}
+
+#[tokio::test]
+async fn test_list_credentials_forbidden() {
+    let mut server = Server::new_async().await;
+    let _key_mock = mock_valid_key(&mut server);
+
+    let _m = server
+        .mock("GET", "/api/v0/user/credentials")
+        .match_query(Matcher::Missing)
+        .with_status(403)
+        .with_body(json!({"error": "Insufficient privileges"}).to_string())
+        .create();
+
+    let config = test_config(&server);
+    let result = ricochet_cli::commands::user::list_credentials(
+        &config,
+        None,
+        None,
+        None,
+        OutputFormat::Table,
+    )
+    .await;
+
+    assert!(result.is_err());
+    _m.assert_async().await;
+}


### PR DESCRIPTION
This PR adds support for a new command `ricochet user credentials` to list all credentials owned by the user.

  <details>
  <summary>AI Summary</summary>

  - `src/client.rs`: new `RicochetClient::list_credentials(user_id, protocol)`, GETs `/api/v0/user/credentials` with
  optional `user_id`/`type` query params, returns `Vec<GitCredential>`.
  - `src/commands/user.rs` (new): `list_credentials` renders table/json/yaml output, following the existing
  `list.rs`/`env_vars.rs` conventions.
  - `src/main.rs`: new `ricochet user credentials [--user-id <ID>] [--type <ssh|https>]` subcommand.
  - `tests/user_credentials_test.rs` (new): 5 mockito-based tests covering success, JSON format, query-param filters,
  empty response, and a 403 error path.
  - Bumped the git-pinned `ricochet-core` dependency in `Cargo.lock` (0.15.0 → 0.16.0) — the previously locked commit
  predated the `GitCredential`/`list_user_creds` types.

  Validated with `cargo check --all-features --workspace`, `cargo clippy --all-targets --all-features -- -D warnings`,
  `cargo fmt --check`, and `cargo test` (all passing), plus a manual run against a live server confirming table output.

  </details>

Instructions-PR: none