### PR TITLE
feat: add --git flag to ricochet deploy

### DIFF
--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -122,6 +122,11 @@ Deploy content to a Ricochet server
 * `-n`, `--name <NAME>` — Name for the deployment
 * `-d`, `--description <DESCRIPTION>` — Description for the deployment
 * `-e`, `--env <KEY[=VALUE]>` — Set an environment variable on the initial deployment. `KEY=VALUE` sets it directly; `KEY` alone resolves the value from .env, .Renviron, or the calling environment. Repeatable
+* `--git <GIT>` — Deploy from a Git repository instead of a local bundle
+* `--branch <BRANCH>` — Git branch to deploy (only with --git)
+* `--path <REPO_PATH>` — Subdirectory within the Git repo containing _ricochet.toml (only with --git)
+* `--config <CONFIG_PATH>` — Path to a local _ricochet.toml to use instead of the one in the repo (only with --git)
+* `--credential <CREDENTIAL>` — Git credential ID to use for private repos (only with --git)
 
 
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,7 +3,7 @@ use anyhow::{Context, Result};
 use colored::Colorize;
 use reqwest::{Client, Response, StatusCode};
 use ricochet_core::{
-    config::git::{GitCredential, GitProtocol},
+    config::git::{GitCredential, GitProtocol, GitRepo},
     content::ContentItem,
 };
 use serde::de::DeserializeOwned;
@@ -279,6 +279,38 @@ impl RicochetClient {
                 }
             }
         }
+    }
+
+    /// Create a Git-backed content item and start its first deployment.
+    /// `config` is the raw `_ricochet.toml` contents; omit to have the server
+    /// read it from the repository itself.
+    pub async fn deploy_git(
+        &self,
+        repo: &GitRepo,
+        config: Option<String>,
+        credential_id: Option<String>,
+    ) -> Result<serde_json::Value> {
+        let mut url = self.base_url.clone();
+        url.set_path("/api/v0/deploy/git");
+
+        let mut form = reqwest::multipart::Form::new().text("repo", serde_json::to_string(repo)?);
+
+        if let Some(cfg) = config {
+            form = form.text("config", cfg);
+        }
+        if let Some(cred) = credential_id {
+            form = form.text("credential_id", cred);
+        }
+
+        let response = self
+            .client
+            .post(url)
+            .header("Authorization", format!("Key {}", self.api_key))
+            .multipart(form)
+            .send()
+            .await?;
+
+        Self::handle_response(response).await
     }
 
     pub async fn get_status(&self, id: &str) -> Result<serde_json::Value> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -282,8 +282,7 @@ impl RicochetClient {
     }
 
     /// Create a Git-backed content item and start its first deployment.
-    /// `config` is the raw `_ricochet.toml` contents; omit to have the server
-    /// read it from the repository itself.
+    /// `config` is the raw `_ricochet.toml` contents; omit it to read the configuration from the repository.
     pub async fn deploy_git(
         &self,
         repo: &GitRepo,

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -3,7 +3,7 @@ use anyhow::{Result, bail};
 use colored::Colorize;
 use dialoguer::{Confirm, theme::ColorfulTheme};
 use indicatif::{ProgressBar, ProgressStyle};
-use ricochet_core::{content::ContentItem, language::Package};
+use ricochet_core::{config::git::GitRepo, content::ContentItem, language::Package};
 use std::path::PathBuf;
 
 pub async fn deploy(
@@ -258,6 +258,65 @@ pub async fn deploy(
                 );
                 anyhow::bail!("")
             }
+            anyhow::bail!("Deployment failed: {}", e)
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn deploy_git(
+    config: &Config,
+    server_ref: Option<&str>,
+    git: String,
+    branch: Option<String>,
+    repo_path: Option<String>,
+    config_path: Option<PathBuf>,
+    credential: Option<String>,
+) -> Result<()> {
+    let server_config = config.resolve_server(server_ref)?;
+    let client = RicochetClient::new(&server_config)?;
+    client.preflight_key_check().await?;
+
+    let repo = GitRepo {
+        url: git,
+        branch,
+        path: repo_path,
+    };
+
+    let toml_content = config_path.map(std::fs::read_to_string).transpose()?;
+
+    println!(
+        "📦 Deploying Git-backed content item from {}\n",
+        repo.url.bright_cyan()
+    );
+
+    let pb = ProgressBar::new_spinner();
+    pb.set_style(
+        ProgressStyle::default_spinner()
+            .template("{spinner:.green} {msg}")
+            .unwrap(),
+    );
+    pb.enable_steady_tick(std::time::Duration::from_millis(80));
+    pb.set_message("Creating content item and starting deployment");
+
+    match client.deploy_git(&repo, toml_content, credential).await {
+        Ok(response) => {
+            pb.finish_and_clear();
+
+            println!("{} Deployment successful!", "✓".green().bold());
+
+            if let Some(id) = response.get("id").and_then(|v| v.as_str()) {
+                let base_url = server_config.url.as_str().trim_end_matches('/');
+                println!("\n{}", "Links:".bold());
+                println!("  App Overview: {}/apps/{}/overview", base_url, id);
+            } else {
+                println!("\n{}", serde_json::to_string_pretty(&response)?);
+            }
+
+            Ok(())
+        }
+        Err(e) => {
+            pb.finish_and_clear();
             anyhow::bail!("Deployment failed: {}", e)
         }
     }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -283,7 +283,10 @@ pub async fn deploy_git(
         path: repo_path,
     };
 
-    let toml_content = config_path.map(std::fs::read_to_string).transpose()?;
+    let toml_content = match config_path {
+        Some(path) => Some(tokio::fs::read_to_string(path).await?),
+        None => None,
+    };
 
     println!(
         "📦 Deploying Git-backed content item from {}\n",
@@ -291,11 +294,7 @@ pub async fn deploy_git(
     );
 
     let pb = ProgressBar::new_spinner();
-    pb.set_style(
-        ProgressStyle::default_spinner()
-            .template("{spinner:.green} {msg}")
-            .unwrap(),
-    );
+    pb.set_style(ProgressStyle::default_spinner().template("{spinner:.green} {msg}")?);
     pb.enable_steady_tick(std::time::Duration::from_millis(80));
     pb.set_message("Creating content item and starting deployment");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,21 @@ enum Commands {
         /// .env, .Renviron, or the calling environment. Repeatable.
         #[arg(short = 'e', long = "env", value_name = "KEY[=VALUE]")]
         env: Vec<String>,
+        /// Deploy from a Git repository instead of a local bundle
+        #[arg(long)]
+        git: Option<String>,
+        /// Git branch to deploy (only with --git)
+        #[arg(long, requires = "git")]
+        branch: Option<String>,
+        /// Subdirectory within the Git repo containing _ricochet.toml (only with --git)
+        #[arg(long = "path", requires = "git")]
+        repo_path: Option<String>,
+        /// Path to a local _ricochet.toml to use instead of the one in the repo (only with --git)
+        #[arg(long = "config", requires = "git")]
+        config_path: Option<std::path::PathBuf>,
+        /// Git credential ID to use for private repos (only with --git)
+        #[arg(long, requires = "git")]
+        credential: Option<String>,
     },
     /// Delete a content item
     Delete {
@@ -446,17 +461,35 @@ async fn main() -> Result<()> {
             name,
             description,
             env,
+            git,
+            branch,
+            repo_path,
+            config_path,
+            credential,
         }) => {
-            commands::deploy::deploy(
-                &config,
-                cli.server.as_deref(),
-                path,
-                name,
-                description,
-                env,
-                cli.debug,
-            )
-            .await?;
+            if let Some(git) = git {
+                commands::deploy::deploy_git(
+                    &config,
+                    cli.server.as_deref(),
+                    git,
+                    branch,
+                    repo_path,
+                    config_path,
+                    credential,
+                )
+                .await?;
+            } else {
+                commands::deploy::deploy(
+                    &config,
+                    cli.server.as_deref(),
+                    path,
+                    name,
+                    description,
+                    env,
+                    cli.debug,
+                )
+                .await?;
+            }
         }
         Some(Commands::Delete { id, force }) => {
             commands::delete::delete(&config, cli.server.as_deref(), &id, force).await?;

--- a/tests/deploy_git_test.rs
+++ b/tests/deploy_git_test.rs
@@ -1,0 +1,142 @@
+use mockito::{Matcher, Server};
+use serde_json::json;
+use url::Url;
+
+fn test_config(server: &Server) -> ricochet_cli::config::Config {
+    ricochet_cli::config::Config::for_test(
+        Url::parse(&server.url()).unwrap(),
+        Some("test_api_key".to_string()),
+    )
+}
+
+// Every command runs a preflight check against this endpoint before doing
+// anything else.
+fn mock_valid_key(server: &mut Server) -> mockito::Mock {
+    server
+        .mock("GET", "/api/v0/check_key")
+        .with_status(200)
+        .create()
+}
+
+#[tokio::test]
+async fn test_deploy_git_success_minimal() {
+    let mut server = Server::new_async().await;
+    let _key_mock = mock_valid_key(&mut server);
+
+    let _m = server
+        .mock("POST", "/api/v0/deploy/git")
+        .match_header("authorization", "Key test_api_key")
+        .match_body(Matcher::Regex("name=\"repo\"".to_string()))
+        .with_status(200)
+        .with_body(json!({"id": "01K66JV2Q123456789ABCDEF"}).to_string())
+        .create();
+
+    let config = test_config(&server);
+    let result = ricochet_cli::commands::deploy::deploy_git(
+        &config,
+        None,
+        "https://github.com/org/repo".to_string(),
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    assert!(result.is_ok(), "expected success, got {result:?}");
+}
+
+#[tokio::test]
+async fn test_deploy_git_success_with_all_fields() {
+    let mut server = Server::new_async().await;
+    let _key_mock = mock_valid_key(&mut server);
+
+    let toml_dir = tempfile::tempdir().unwrap();
+    let toml_path = toml_dir.path().join("_ricochet.toml");
+    std::fs::write(&toml_path, "[content]\ncontent_type = \"shiny\"\n").unwrap();
+
+    let _m = server
+        .mock("POST", "/api/v0/deploy/git")
+        .match_header("authorization", "Key test_api_key")
+        .match_body(Matcher::AllOf(vec![
+            Matcher::Regex("name=\"repo\"".to_string()),
+            Matcher::Regex("name=\"config\"".to_string()),
+            Matcher::Regex("name=\"credential_id\"".to_string()),
+            Matcher::Regex("\"branch\":\"main\"".to_string()),
+            Matcher::Regex("\"path\":\"apps/dashboard\"".to_string()),
+        ]))
+        .with_status(200)
+        .with_body(json!({"id": "01K66JV2Q123456789ABCDEF"}).to_string())
+        .create();
+
+    let config = test_config(&server);
+    let result = ricochet_cli::commands::deploy::deploy_git(
+        &config,
+        None,
+        "https://github.com/org/repo".to_string(),
+        Some("main".to_string()),
+        Some("apps/dashboard".to_string()),
+        Some(toml_path),
+        Some("cred_123".to_string()),
+    )
+    .await;
+
+    assert!(result.is_ok(), "expected success, got {result:?}");
+    _m.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_deploy_git_bad_request() {
+    let mut server = Server::new_async().await;
+    let _key_mock = mock_valid_key(&mut server);
+
+    let _m = server
+        .mock("POST", "/api/v0/deploy/git")
+        .match_header("authorization", "Key test_api_key")
+        .with_status(400)
+        .with_body(json!({"error": "Invalid deployment data"}).to_string())
+        .create();
+
+    let config = test_config(&server);
+    let result = ricochet_cli::commands::deploy::deploy_git(
+        &config,
+        None,
+        "https://github.com/org/repo".to_string(),
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    assert!(result.is_err());
+    _m.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_deploy_git_forbidden() {
+    let mut server = Server::new_async().await;
+    let _key_mock = mock_valid_key(&mut server);
+
+    let _m = server
+        .mock("POST", "/api/v0/deploy/git")
+        .match_header("authorization", "Key test_api_key")
+        .with_status(403)
+        .with_body(json!({"error": "Insufficient privileges"}).to_string())
+        .create();
+
+    let config = test_config(&server);
+    let result = ricochet_cli::commands::deploy::deploy_git(
+        &config,
+        None,
+        "https://github.com/org/repo".to_string(),
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    assert!(result.is_err());
+    _m.assert_async().await;
+}


### PR DESCRIPTION
Add `--git` to `ricochet deploy` to create and deploy a Git-backed content item via `/api/v0/deploy/git` in the dev version of ricochet.

This adds arguments:

- `--git`
-  `--branch`
- `--path`
- `--config`
- `--credential`

The latter are only available when `--git` is provided. 

Closes https://github.com/ricochet-rs/cli/issues/184

  <details>
  <summary>AI Summary</summary>

  - `src/client.rs`: new `RicochetClient::deploy_git(repo, config, credential_id)`, POSTs multipart (`repo`, optional
  `config`, optional `credential_id`) to `/api/v0/deploy/git`.
  - `src/commands/deploy.rs`: new `deploy_git()` builds a `GitRepo` from the CLI flags, optionally reads a local
  `_ricochet.toml` to send as raw `config`, calls the client, and prints the app overview link on success.
  - `src/main.rs`: `deploy` gains `--git <URL>`, `--branch`, `--path` (repo subdirectory), `--config` (local toml
  path), `--credential`, all gated with `requires = "git"` so they're rejected unless `--git` is set. Dispatch branches
  to `deploy_git` vs the existing local-bundle `deploy`.
  - `tests/deploy_git_test.rs` (new): 4 mockito-based tests — minimal success, success with all fields set (asserts the
  multipart body contains `repo`/`config`/`credential_id` and the JSON-encoded branch/path), a 400, and a 403.
  - `docs/cli-commands.md` regenerated to include the new flags.

  Validated with `cargo check --all-features --workspace`, `cargo clippy --all-targets --all-features -- -D warnings`,
  `cargo fmt --check`, `cargo test` (all passing), and a manual deploy against a live server
  (`https://github.com/ricochet-rs/test-apps`, `--path r/waiting`) confirming the full create-and-deploy flow.

  </details>

Instructions-PR: none
