### PR TITLE
chore: bump ricochet-core to 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2321,7 +2321,7 @@ dependencies = [
 [[package]]
 name = "ricochet-core"
 version = "0.16.0"
-source = "git+https://github.com/ricochet-rs/ricochet#d98cdd447b1e95a88312f72e22ec799497b19977"
+source = "git+https://github.com/ricochet-rs/ricochet?tag=v0.17.0#9e168f013c50e81ab536088dc408c3cdc9b408b3"
 dependencies = [
  "anyhow",
  "bytesize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ reqwest = { version = "0.13", default-features = false, features = [
   "stream"
 ] }
 jiff = { version = "0.2", features = ["serde"] }
-ricochet-core = { git = "https://github.com/ricochet-rs/ricochet", default-features = false }
+ricochet-core = { git = "https://github.com/ricochet-rs/ricochet", tag = "v0.17.0", default-features = false }
 self-replace = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Pins ricochet-core to its v0.17.0 release tag so CLI builds use the intended core release.

<details>
<summary>AI Summary</summary>

The ricochet-core Git dependency now selects the v0.17.0 tag instead of following the repository default branch.
Cargo.lock resolves the dependency to release commit 9e168f013c50e81ab536088dc408c3cdc9b408b3.
The upstream release tag still declares the crate metadata version as 0.16.0.

Validation:

- `just fmt`
- `just lint`
- `cargo check --workspace --all-targets --all-features`
- `cargo test --all-features -- --test-threads=1` (208 tests passed)

</details>

Instructions-PR: none
