### PR TITLE
feat(skills): add a ricochet-cli agent skill

### DIFF
--- a/.claude/skills/ricochet-cli/SKILL.md
+++ b/.claude/skills/ricochet-cli/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: ricochet-cli
+description: Use when deploying or operating Ricochet content with the `ricochet` CLI, including authoring a `_ricochet.toml`, connecting to servers, managing environment variables, invoking or scheduling tasks, and diagnosing CLI errors.
+---
+
+# Use the Ricochet CLI
+
+`ricochet` deploys content to a Ricochet server and manages that content afterwards.
+Read [references/ricochet-toml.md](references/ricochet-toml.md) before writing or editing a `_ricochet.toml`.
+Run `ricochet <COMMAND> --help` for exhaustive flags, or read `docs/cli-commands.md` in the `ricochet-rs/cli` repository.
+
+## Work non-interactively
+
+`ricochet init` refuses to run when stdin is not a terminal, when `CI` is set, when `CARGO_MANIFEST_DIR` is set, or when `RICOCHET_NON_INTERACTIVE` is set.
+Write `_ricochet.toml` by hand instead of calling `ricochet init` from an agent session or a CI job.
+Under the same conditions `ricochet deploy` fails with `No _ricochet.toml found` rather than offering to create one.
+
+Pass `-F json` to any command whose output must be parsed.
+Pass `--debug` to surface the underlying request and response when a command fails.
+
+## Connect to a server
+
+Servers are named profiles in `~/.config/ricochet/config.toml` on every platform.
+Add one, then make it the default:
+
+```sh
+ricochet server add production https://ricochet.example.com --default
+ricochet server list
+ricochet server set-default production
+```
+
+The URL must carry an `http://` or `https://` scheme.
+`ricochet login` opens a browser callback flow, falls back to pasting a key when no display server is present, and accepts a key directly with `-k`:
+
+```sh
+ricochet login -S production
+ricochet login -S https://ricochet.example.com -k rico_...
+```
+
+Keys minted by `ricochet login` expire after 8 hours, so a long-lived automation key must be created in the web UI and supplied through `RICOCHET_API_KEY`.
+`ricochet config` prints the resolved configuration, and `ricochet config -A` includes the stored keys.
+
+Server resolution runs in this order:
+
+1. `RICOCHET_SERVER`, which is read before anything else and therefore overrides `-S`.
+2. The `-S/--server` value, matched first against profile names and then against configured URLs.
+3. The `default_server` profile.
+
+`RICOCHET_API_KEY` replaces the stored key for whichever server was resolved.
+An unknown `-S` value fails with `Server '<name>' not found` and lists the configured profiles.
+
+## Describe the content item
+
+Every deployable directory holds a `_ricochet.toml` next to its package lockfile.
+A minimal task looks like this:
+
+```toml
+[content]
+name = "weekly-report"
+entrypoint = "report.qmd"
+access_type = "private"
+content_type = "quarto-r"
+
+[language]
+name = "r"
+packages = "renv.lock"
+
+[schedule]
+cron = "0 9 * * 1-5"
+```
+
+`content.id` is absent on a brand new item.
+The first successful `ricochet deploy` writes the assigned ULID back into the file, and every later deploy of that directory updates the same item.
+Most `app` and `task` subcommands read that ID from the local file when the `ID` argument is omitted, so run them from the content directory or point `-p` at the file.
+
+The lockfile named by `language.packages` must exist before deploying: `renv.lock` for R, `uv.lock` for Python, and `Manifest.toml` for Julia.
+Python items additionally need a `.python-version`.
+For both files the CLI searches parent directories, which is how uv workspaces keep a single lockfile at the workspace root.
+
+## Deploy
+
+```sh
+ricochet deploy
+ricochet deploy ./reports -S staging
+ricochet deploy -e DATABASE_URL -e LOG_LEVEL=debug
+```
+
+The path argument must be a directory containing `_ricochet.toml`, not the TOML file itself.
+Everything under that directory is bundled except `.venv`, `.renv`, and `__pycache__`, which are dropped even when an `include` pattern names them.
+Narrow the bundle with `content.include` and `content.exclude` globs.
+
+`-e KEY=VALUE` sets a variable directly, while `-e KEY` alone resolves the value from `.env`, then `.Renviron`, then the calling environment.
+Values are encrypted with the server's public key before they leave the machine, and only the keys named on the command line are sent.
+`-e` applies to a content item's first deployment only; use `ricochet app env-vars` or `ricochet task env-vars` after that.
+
+Git-backed items skip local bundling entirely:
+
+```sh
+ricochet user credentials
+ricochet deploy --git https://github.com/acme/reports --branch main --path dashboards --credential <CREDENTIAL_ID>
+```
+
+## Operate apps
+
+```sh
+ricochet app list -a --sort=-updated
+ricochet app instances
+ricochet app stop
+ricochet app stop <ID> <INSTANCE_ID>
+ricochet app toml <ID>
+ricochet app deployment list <ID> --fields all
+ricochet app deployment get <DEPLOYMENT_ID>
+```
+
+`ricochet app stop` with no instance argument stops every instance of the item.
+`ricochet app toml` fetches the deployed `_ricochet.toml`, which is the fastest way to see what the server actually believes about an item.
+
+## Operate tasks
+
+Tasks are the content types that can be invoked rather than served: `r`, `rmd`, `julia`, `python`, `quarto-r`, `quarto-jl`, and `quarto-py`.
+
+```sh
+ricochet task list
+ricochet task invoke <ID>
+ricochet task schedule <ID> "0 9 * * 1-5"
+```
+
+`ricochet task invoke` starts a run and returns the invocation record immediately, so its reported status is usually `pending` or `running` rather than a final result.
+The CLI has no command that polls an invocation, so follow the run in the web UI.
+`ricochet task schedule` validates the cron expression locally, then prints the parsed description and the next run time in UTC.
+A schedule can also be declared in `[schedule]` and applied with `ricochet task settings update`.
+
+## Change settings after the first deployment
+
+`_ricochet.toml` edits do not reach the server until they are applied explicitly:
+
+```sh
+ricochet app settings
+ricochet app settings update
+ricochet task settings update -f
+```
+
+The bare `settings` command prints the diff between the local file and the deployed item.
+`update` applies it, prompting unless `-f` is given.
+
+## Manage environment variables
+
+```sh
+ricochet app env-vars get
+ricochet app env-vars set API_TOKEN LOG_LEVEL=debug
+ricochet app env-vars delete API_TOKEN
+ricochet app env-vars replace API_TOKEN=abc
+```
+
+`get` returns names only, never values.
+`set` upserts and leaves unlisted variables untouched, while `replace` deletes every variable that is not listed, including all of them when no argument is given.
+The bare `KEY` form resolves from `.env`, `.Renviron`, or the environment, exactly as it does for `ricochet deploy -e`.
+The same four subcommands exist under `ricochet task`.
+
+## Diagnose common errors
+
+| Message                                                                      | Cause and fix                                                                                                                                                                                    |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `No API key configured`                                                      | The resolved server profile has no key. Run `ricochet login -S <profile>`, or set `RICOCHET_API_KEY`.                                                                                            |
+| `Credentials are invalid or expired for server <url>`                        | The stored key is missing, wrong, or past its 8 hour lifetime. Run `ricochet login -S <url>`.                                                                                                    |
+| `Cannot run init in non-interactive mode`                                    | `ricochet init` needs a TTY. Write `_ricochet.toml` by hand using the schema reference.                                                                                                          |
+| `No _ricochet.toml found in <dir>`                                           | Non-interactive deploy without a config file. Create the file, or point the path argument at the directory that holds it.                                                                        |
+| `Path must be a directory containing _ricochet.toml`                         | The path argument pointed at a file. Pass the containing directory.                                                                                                                              |
+| ``Required package file `renv.lock` not found``                              | Run `renv::snapshot()` in R, `uv init` for `uv.lock`, or `Pkg.instantiate()` in Julia.                                                                                                           |
+| ``Please create a `.python-version` via `uv python pin```                    | Python items need a pinned interpreter version beside `uv.lock` or at the workspace root.                                                                                                        |
+| `403` while redeploying an existing ID                                       | The ID does not exist on this server, the key lacks permission, or the item belongs to another server. Verify with `ricochet app list`, check `-S`, or delete `content.id` to create a new item. |
+| `Environment variables can only be set on a content item's first deployment` | Redeploy without `-e`, then use `ricochet app env-vars set`.                                                                                                                                     |
+| `Server '<name>' not found`                                                  | The profile is not configured. Run `ricochet server list`, then `ricochet server add`.                                                                                                           |
+| `Server URL must include the scheme prefix`                                  | Prefix the URL with `http://` or `https://`.                                                                                                                                                     |
+| `Local _ricochet.toml has no item ID`                                        | The item was never deployed. Run `ricochet deploy` once, or pass the ID explicitly.                                                                                                              |
+| `Package file required`                                                      | A Python item declared a non-uv lockfile. Set `packages = "uv.lock"`.                                                                                                                            |
+| `Chosen content type cannot be served`                                       | A task content type declared `[serve]`. Remove the table.                                                                                                                                        |
+| `Chosen content type cannot be scheduled. It must be served.`                | An app content type declared `[schedule]`. Remove the table.                                                                                                                                     |
+| `Chosen content type cannot be served as a static site`                      | An app content type declared `[static]`. Remove the table.                                                                                                                                       |
+| `Invalid entrypoint`                                                         | The entrypoint extension does not match the content type. See the validation rules in the schema reference.                                                                                      |
+
+## Keep the CLI current
+
+```sh
+ricochet self update --dry-run
+ricochet self update
+```
+
+Automatic update checks are suppressed when `CI` or `RICOCHET_NO_UPDATE_CHECK` is set, when `skip_update_check` is true in the config, and for Homebrew installations.

--- a/.claude/skills/ricochet-cli/SKILL.md
+++ b/.claude/skills/ricochet-cli/SKILL.md
@@ -30,7 +30,8 @@ ricochet server set-default production
 ```
 
 The URL must carry an `http://` or `https://` scheme.
-`ricochet login` opens a browser callback flow, falls back to pasting a key when no display server is present, and accepts a key directly with `-k`:
+`ricochet login` opens a browser callback flow, falls back to pasting a key when no display server is present, and accepts a key directly with `-k`.
+It is recommended to login via the web UI first before running this command.
 
 ```sh
 ricochet login -S production

--- a/.claude/skills/ricochet-cli/references/ricochet-toml.md
+++ b/.claude/skills/ricochet-cli/references/ricochet-toml.md
@@ -1,0 +1,238 @@
+# `_ricochet.toml` schema
+
+A `_ricochet.toml` describes one content item.
+It lives in the directory that is deployed, beside the package lockfile.
+The schema below matches `ricochet_core::content::ContentItem` as of `ricochet-core` 0.17.0.
+
+Only `[content]` and `[language]` are required.
+Every other table is optional, and several are rejected outright for the wrong content type.
+
+## `[content]`
+
+| Key            | Type             | Required | Notes                                                                                                 |
+| -------------- | ---------------- | -------- | ----------------------------------------------------------------------------------------------------- |
+| `id`           | string           | no       | The item ULID. Leave it out for a new item. The first successful deploy writes it back into the file. |
+| `name`         | string           | yes      | Display name, 120 characters or fewer.                                                                |
+| `slug`         | string           | no       | URL slug. The server derives one from the name when this is absent.                                   |
+| `entrypoint`   | path             | yes      | Relative to the deployed directory. Allowed extensions depend on `content_type`.                      |
+| `access_type`  | enum             | yes      | `private`, `internal`, or `external`.                                                                 |
+| `content_type` | enum             | yes      | See the content type table below.                                                                     |
+| `summary`      | string           | no       | Short description shown in the UI.                                                                    |
+| `thumbnail`    | path             | no       | Relative path to a thumbnail image.                                                                   |
+| `tags`         | array of strings | no       | Free-form tags.                                                                                       |
+| `include`      | array of globs   | no       | When set, only matching paths are bundled.                                                            |
+| `exclude`      | array of globs   | no       | Matching paths are dropped after `include` is applied.                                                |
+| `exec_env`     | string           | no       | Named execution environment, for servers with a Docker or Kubernetes backend.                         |
+
+`.venv`, `.renv`, and `__pycache__` are always excluded, at any nesting depth, even when an `include` pattern names them.
+
+## `[language]`
+
+| Key        | Type | Required | Notes                                                      |
+| ---------- | ---- | -------- | ---------------------------------------------------------- |
+| `name`     | enum | yes      | `r`, `python`, or `julia`. Must agree with `content_type`. |
+| `packages` | enum | yes      | `renv.lock`, `uv.lock`, or `Manifest.toml`.                |
+
+Python items must use `packages = "uv.lock"`; any other value fails validation with `Package file required`.
+The named lockfile must exist in the deployed directory, or in a parent directory for `uv.lock`.
+
+## `[schedule]`
+
+Valid only for task content types.
+Declaring it on an app fails validation with `Chosen content type cannot be scheduled`.
+
+| Key             | Type             | Default | Notes                                                                                                                                |
+| --------------- | ---------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `cron`          | string           | none    | A cron expression such as `0 9 * * 1-5`, or a shorthand such as `@hourly`, `@daily`, or `@weekly`. Validated locally at deploy time. |
+| `parameterized` | bool             | `false` | Whether the task accepts parameters at invocation.                                                                                   |
+| `on_success`    | array of strings | none    | Notification targets for a successful run.                                                                                           |
+| `on_error`      | array of strings | none    | Notification targets for a failed run.                                                                                               |
+
+## `[serve]`
+
+Valid only for app content types.
+Declaring it on a task fails with `Chosen content type cannot be served.`
+The four sizing keys have no serde defaults, so all of them must be present once the table exists.
+
+| Key                  | Type            | Suggested value | Notes                                                                                       |
+| -------------------- | --------------- | --------------- | ------------------------------------------------------------------------------------------- |
+| `min_instances`      | integer         | `0`             | Instances started eagerly.                                                                  |
+| `max_instances`      | integer         | `5`             | Hard ceiling on concurrent instances. Clamped up to `min_instances` when lower.             |
+| `spawn_threshold`    | integer         | `80`            | Percentage of `max_connections` at which a new instance spawns. Clamped to 100.             |
+| `max_connections`    | integer         | `10`            | Connections a single instance will accept.                                                  |
+| `max_connection_age` | integer seconds | unset           | Maximum lifetime of an instance. Unset means instances end when the last connection closes. |
+| `inactive_timeout`   | integer seconds | unset           | Idle time before a connection is closed.                                                    |
+| `connection_timeout` | integer seconds | unset           | Time allowed to establish a connection.                                                     |
+
+### `[serve.k8s]`
+
+| Key               | Type   | Default   | Notes                                                   |
+| ----------------- | ------ | --------- | ------------------------------------------------------- |
+| `strategy`        | enum   | `rolling` | `rolling` or `recreate`.                                |
+| `max_surge`       | string | unset     | Count or percentage, such as `1` or `25%`.              |
+| `max_unavailable` | string | unset     | Count or percentage, such as `0` or `10%`.              |
+| `config`          | string | unset     | Raw backend configuration passed through to Kubernetes. |
+
+## `[static]`
+
+Valid only for content types that can produce static output, which is the same set as the task types.
+Declaring it on an app fails with `Chosen content type cannot be served as a static site.`
+
+| Key          | Type   | Notes                                                                      |
+| ------------ | ------ | -------------------------------------------------------------------------- |
+| `index`      | string | File served at the item root, conventionally `index.html`.                 |
+| `output_dir` | string | Directory holding the rendered output, relative to the deployed directory. |
+| `render_fn`  | string | Custom render function, when the default renderer is not used.             |
+
+`ricochet init` fills both keys automatically for a Quarto project by reading `project.output-dir` from `_quarto.yml`.
+
+## `[resources]`
+
+Infrastructure-agnostic limits, applied by the Docker and Kubernetes backends.
+Unset keys fall back to the server-wide defaults.
+
+| Key               | Type            | Example   | Notes                                                             |
+| ----------------- | --------------- | --------- | ----------------------------------------------------------------- |
+| `cpu_request`     | string          | `"500m"`  | Millicores, or a plain number of cores.                           |
+| `cpu_limit`       | string          | `"1000m"` | Same format as `cpu_request`.                                     |
+| `memory_request`  | string          | `"256Mi"` | `Ki`, `Mi`, or `Gi` suffix, or plain bytes.                       |
+| `memory_limit`    | string          | `"512Mi"` | Same format as `memory_request`.                                  |
+| `restore_timeout` | integer seconds | `1800`    | Timeout for the dependency restore job. `0` disables the timeout. |
+
+## `[repositories]`
+
+Package sources, keyed by language.
+R takes a named map, while Python and Julia take arrays of URLs.
+
+| Key               | Type                 | Default | Notes                                                                                                         |
+| ----------------- | -------------------- | ------- | ------------------------------------------------------------------------------------------------------------- |
+| `r`               | table of name to URL | unset   | For example `{ CRAN = "https://cloud.r-project.org" }`. Unnamed lists are ignored with a warning.             |
+| `python`          | array of URLs        | unset   | Named maps are ignored with a warning.                                                                        |
+| `julia`           | array of URLs        | unset   | Named maps are ignored with a warning.                                                                        |
+| `allow_overrides` | bool                 | `true`  | Read from the server configuration. When the server sets it to false, these item-level sources are discarded. |
+
+Item sources are merged into the server sources, and the item wins on a name collision.
+
+## `[retention]`
+
+Per-item bundle retention.
+An item can only tighten the server-wide policy, never relax it, because the resolver takes the lower of the two values.
+
+| Key               | Type      | Default | Notes                                  |
+| ----------------- | --------- | ------- | -------------------------------------- |
+| `max_age_days`    | integer   | unset   | Delete deployments older than this.    |
+| `max_deployments` | integer   | `20`    | Deployments kept per item.             |
+| `max_bundle_size` | byte size | `100MB` | Largest bundle the server will accept. |
+
+## `[env_vars]`
+
+Written by the CLI, never by hand.
+It holds the AES-encrypted payload produced by `ricochet deploy -e` as `nonce` and `vars`, both base64.
+Manage variables with `ricochet app env-vars` or `ricochet task env-vars` instead of editing this table.
+
+## Content types
+
+`task` types are invokable, schedulable, and can be served as static output.
+`app` types are served live and reject `[schedule]` and `[static]`.
+
+| `content_type`   | `language.name` | Kind | Entrypoint                                                |
+| ---------------- | --------------- | ---- | --------------------------------------------------------- |
+| `r`              | `r`             | task | `.R`                                                      |
+| `rmd`            | `r`             | task | `.Rmd` or `.R`                                            |
+| `quarto-r`       | `r`             | task | `.qmd`, `.Rmd`, `.R`, or `_quarto.yml`                    |
+| `julia`          | `julia`         | task | `.jl`                                                     |
+| `quarto-jl`      | `julia`         | task | `.qmd` or `_quarto.yml`                                   |
+| `python`         | `python`        | task | `.py`                                                     |
+| `quarto-py`      | `python`        | task | `.qmd` or `_quarto.yml`                                   |
+| `shiny`          | `r`             | app  | A directory holding `ui.R` and `server.R`, or a `.R` file |
+| `rmd-shiny`      | `r`             | app  | `.Rmd` or `.R`                                            |
+| `quarto-r-shiny` | `r`             | app  | `.qmd`, `.Rmd`, `.R`, or `_quarto.yml`                    |
+| `plumber`        | `r`             | app  | Any `.R` file                                             |
+| `ambiorix`       | `r`             | app  | `.R`                                                      |
+| `r-service`      | `r`             | app  | `.R`                                                      |
+| `serverless-r`   | `r`             | app  | `.R`                                                      |
+| `julia-service`  | `julia`         | app  | `.jl`                                                     |
+| `shiny-py`       | `python`        | app  | A directory, or a `.py` file                              |
+| `python-service` | `python`        | app  | `.py`                                                     |
+| `fast-api`       | `python`        | app  | `.py`                                                     |
+| `flask`          | `python`        | app  | `.py`                                                     |
+| `streamlit`      | `python`        | app  | `.py`                                                     |
+| `dash`           | `python`        | app  | `.py`                                                     |
+
+## Examples
+
+A scheduled Quarto report rendered to a static site:
+
+```toml
+[content]
+id = "01KE52BY41EQ7NE89K7Z5MMZ84"
+name = "Weekly sales report"
+entrypoint = "report.qmd"
+access_type = "internal"
+content_type = "quarto-r"
+summary = "Sales rollup, refreshed every weekday morning."
+tags = ["sales", "reporting"]
+exclude = ["data/raw/**"]
+
+[language]
+name = "r"
+packages = "renv.lock"
+
+[schedule]
+cron = "0 9 * * 1-5"
+
+[static]
+index = "index.html"
+output_dir = "_site"
+
+[retention]
+max_deployments = 10
+```
+
+A Shiny app with sizing and resource limits:
+
+```toml
+[content]
+name = "Fleet dashboard"
+entrypoint = "app.R"
+access_type = "external"
+content_type = "shiny"
+
+[language]
+name = "r"
+packages = "renv.lock"
+
+[serve]
+min_instances = 1
+max_instances = 10
+spawn_threshold = 75
+max_connections = 20
+inactive_timeout = 900
+
+[resources]
+cpu_limit = "1000m"
+memory_limit = "2Gi"
+```
+
+A Python service on uv:
+
+```toml
+[content]
+name = "scoring-api"
+entrypoint = "main.py"
+access_type = "internal"
+content_type = "fast-api"
+
+[language]
+name = "python"
+packages = "uv.lock"
+
+[serve]
+min_instances = 1
+max_instances = 4
+spawn_threshold = 80
+max_connections = 50
+
+[repositories]
+python = ["https://pypi.org/simple"]
+```

--- a/.claude/skills/ricochet-cli/references/ricochet-toml.md
+++ b/.claude/skills/ricochet-cli/references/ricochet-toml.md
@@ -124,7 +124,6 @@ An item can only tighten the server-wide policy, never relax it, because the res
 | `max_deployments` | integer   | `20`    | Deployments kept per item.             |
 | `max_bundle_size` | byte size | `100MB` | Largest bundle the server will accept. |
 
-
 ## Content types
 
 `task` types are invokable, schedulable, and can be served as static output.

--- a/.claude/skills/ricochet-cli/references/ricochet-toml.md
+++ b/.claude/skills/ricochet-cli/references/ricochet-toml.md
@@ -124,11 +124,6 @@ An item can only tighten the server-wide policy, never relax it, because the res
 | `max_deployments` | integer   | `20`    | Deployments kept per item.             |
 | `max_bundle_size` | byte size | `100MB` | Largest bundle the server will accept. |
 
-## `[env_vars]`
-
-Written by the CLI, never by hand.
-It holds the AES-encrypted payload produced by `ricochet deploy -e` as `nonce` and `vars`, both base64.
-Manage variables with `ricochet app env-vars` or `ricochet task env-vars` instead of editing this table.
 
 ## Content types
 


### PR DESCRIPTION
Add a `ricochet-cli` agent skill documenting how to author a `_ricochet.toml`, connect to servers, deploy, invoke and schedule tasks, and diagnose CLI errors.

<details>
<summary>AI Summary</summary>

Closes #201, which asked for a skill covering the `_ricochet.toml` schema, connecting to a server, server configs, common errors, and task invocation.

`.claude/skills/ricochet-cli/SKILL.md` is workflow-shaped rather than a flag reference, because `docs/cli-commands.md` is generated from clap and already covers every flag, and the skill links to it for that purpose. It leads with non-interactive operation, since `ricochet init` hard-fails whenever stdin is not a terminal or `CI` or `CARGO_MANIFEST_DIR` is set, which is the situation every agent and CI job is in, so the practical instruction is to write `_ricochet.toml` by hand. The remaining sections cover server profiles and the resolution order, where `RICOCHET_SERVER` is read before `-S` and therefore overrides it, `_ricochet.toml` and lockfile requirements, local and Git-backed deploys, app and task operations, `settings update` as the only path from a local TOML edit to the server, environment variables, and a table mapping 17 literal CLI error strings to their causes.

`.claude/skills/ricochet-cli/references/ricochet-toml.md` documents every table in `ricochet_core::content::ContentItem` as of ricochet-core 0.17.0: `[content]`, `[language]`, `[schedule]`, `[serve]` with `[serve.k8s]`, `[static]`, `[resources]`, `[repositories]`, and `[retention]`, plus a note that `[env_vars]` holds CLI-written encrypted output and is never hand-authored. It adds a 21-row content type matrix giving the serde kebab-case value, the required language, whether the type is a task or an app, and the allowed entrypoint extensions, followed by three worked examples.

Content type values are taken from the serde `kebab-case` derivation used to deserialize the file, not from the `FromStr` list, which is only reachable from string parsing and contains a typo.

No Rust changed, so this is documentation only.

Validation:

- `prek run -a` passes every hook, including markdownlint-cli2, prettier, editorconfig-checker, and `cargo fmt`.
- Two claims were checked against an installed `ricochet` binary rather than assumed. `ricochet app list -a -s -updated` is a clap parse error, so the example uses `--sort=-updated`, which parses. The `Cannot run init in non-interactive mode` message was reproduced verbatim.
- An initial draft suggested polling `ricochet task deployment list` for invocation results. That was removed, because deployments and invocations are distinct and the CLI has no invocation-polling command.

The session produced no durable lesson for `CLAUDE.md`, so no instruction file changed.

</details>

Instructions-PR: https://github.com/ricochet-rs/agent-instructions/pull/29
