### PR TITLE
feat(list): add --all to list every item on the instance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,3 +121,4 @@ On a tagged release, the `binaries.yaml` pipeline:
 - HTTP client uses reqwest with 5-minute timeout
 - File uploads support both individual files and directory bundling (creates tar.gz)
 - Uses ULID for unique identifiers
+- The CLI ships independently of the server; a new API query parameter is silently ignored by servers that predate it, so detect support from a field in the response rather than assuming the request was honored

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -221,6 +221,7 @@ List deployed app content items
 
 * `-t`, `--content-type <CONTENT_TYPE>` — Filter by content type
 * `-a`, `--active-only` — Show only active deployments (status: deployed, running, or success)
+* `--all` — List every item on the instance, not just your own (requires an instance admin API key)
 * `-s`, `--sort <SORT>` — Sort by field(s) - comma-separated for multiple (e.g., "name,updated" or "status,name") Prefix with '-' for descending order (e.g., "-updated,name")
 
 
@@ -440,6 +441,7 @@ List deployed task content items
 
 * `-t`, `--content-type <CONTENT_TYPE>` — Filter by content type
 * `-a`, `--active-only` — Show only active deployments (status: deployed, running, or success)
+* `--all` — List every item on the instance, not just your own (requires an instance admin API key)
 * `-s`, `--sort <SORT>` — Sort by field(s) - comma-separated for multiple (e.g., "name,updated" or "status,name") Prefix with '-' for descending order (e.g., "-updated,name")
 
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -42,6 +42,15 @@ impl<R: AsyncRead + Unpin> AsyncRead for ProgressReader<R> {
     }
 }
 
+/// Which content items the server should return from the item listing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ItemScope {
+    /// Only the items the caller has an ACL entry for.
+    Owned,
+    /// Every item on the instance, which the server allows for admins only.
+    All,
+}
+
 pub struct RicochetClient {
     pub(crate) client: Client,
     pub(crate) base_url: Url,
@@ -158,9 +167,16 @@ impl RicochetClient {
         }
     }
 
-    pub async fn list_items(&self) -> Result<Vec<serde_json::Value>> {
+    pub async fn list_items(&self, scope: ItemScope) -> Result<Vec<serde_json::Value>> {
         let mut url = self.base_url.clone();
         url.set_path("/api/v0/user/items");
+        match scope {
+            // Omitting the parameter keeps the request identical to the one
+            // servers without the instance-wide listing already answer.
+            ItemScope::Owned => {}
+            ItemScope::All => url.set_query(Some("scope=all")),
+        }
+
         let response = self
             .client
             .get(url)
@@ -168,16 +184,29 @@ impl RicochetClient {
             .send()
             .await?;
 
-        match Self::handle_response(response).await {
-            Ok(result) => Ok(result),
-            Err(e) => {
-                // Check if this is an authentication error
-                if e.to_string().contains("403") && e.to_string().contains("Invalid API key") {
-                    let masked_key = Self::mask_api_key(&self.api_key);
-                    anyhow::bail!("Authentication failed. API key used: {}", masked_key)
-                } else {
-                    Err(e)
-                }
+        if response.status() == StatusCode::FORBIDDEN {
+            let body = response.text().await.unwrap_or_default();
+            return Err(self.forbidden_listing_error(scope, &body));
+        }
+
+        Self::handle_response(response).await
+    }
+
+    /// Explain a 403 from the item listing in terms of what the caller asked for.
+    fn forbidden_listing_error(&self, scope: ItemScope, body: &str) -> anyhow::Error {
+        if body.contains("Invalid API key") {
+            return anyhow::anyhow!(
+                "Authentication failed. API key used: {}",
+                Self::mask_api_key(&self.api_key)
+            );
+        }
+
+        match scope {
+            ItemScope::All => anyhow::anyhow!(
+                "Listing every item on the instance requires an instance admin API key.\nServer response: {body}"
+            ),
+            ItemScope::Owned => {
+                anyhow::anyhow!("Request failed with status 403 Forbidden: {body}")
             }
         }
     }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -33,19 +33,11 @@ pub fn classify_item(item: &serde_json::Value) -> Option<ListKind> {
     }
 }
 
-/// Render an item's owner, which only the instance-wide listing returns.
+/// Render an item's owner, whom the server names by display name, email or id.
 fn owner_label(item: &serde_json::Value) -> Option<String> {
-    let owner = item
-        .get("owner")
-        .or_else(|| item.get("owner_name"))
-        .or_else(|| item.get("owner_email"))
-        .or_else(|| item.get("owner_id"))?;
+    let owner = item.get("owner")?;
 
-    if let Some(text) = owner.as_str() {
-        return Some(text.to_string());
-    }
-
-    ["email", "username", "name", "id"]
+    ["display_name", "email", "id"]
         .iter()
         .find_map(|field| owner.get(field).and_then(|v| v.as_str()))
         .map(str::to_string)

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,4 +1,9 @@
-use crate::{OutputFormat, client::RicochetClient, config::Config, utils};
+use crate::{
+    OutputFormat,
+    client::{ItemScope, RicochetClient},
+    config::Config,
+    utils,
+};
 use anyhow::Result;
 use colored::Colorize;
 use comfy_table::{Cell, Color, Table, presets::UTF8_FULL};
@@ -28,8 +33,35 @@ pub fn classify_item(item: &serde_json::Value) -> Option<ListKind> {
     }
 }
 
+/// Render an item's owner, which only the instance-wide listing returns.
+fn owner_label(item: &serde_json::Value) -> Option<String> {
+    let owner = item
+        .get("owner")
+        .or_else(|| item.get("owner_name"))
+        .or_else(|| item.get("owner_email"))
+        .or_else(|| item.get("owner_id"))?;
+
+    if let Some(text) = owner.as_str() {
+        return Some(text.to_string());
+    }
+
+    ["email", "username", "name", "id"]
+        .iter()
+        .find_map(|field| owner.get(field).and_then(|v| v.as_str()))
+        .map(str::to_string)
+}
+
 // Helper function to compare items by a specific field
 fn compare_by_field(a: &serde_json::Value, b: &serde_json::Value, field: &str) -> Ordering {
+    if field == "owner" {
+        return match (owner_label(a), owner_label(b)) {
+            (None, None) => Ordering::Equal,
+            (None, Some(_)) => Ordering::Greater,
+            (Some(_), None) => Ordering::Less,
+            (Some(a), Some(b)) => a.to_lowercase().cmp(&b.to_lowercase()),
+        };
+    }
+
     let a_val = match field {
         "status" => a
             .get("status")
@@ -70,6 +102,7 @@ pub async fn list(
     config: &Config,
     server_ref: Option<&str>,
     kind: ListKind,
+    scope: ItemScope,
     content_type: Option<String>,
     active_only: bool,
     sort_fields: Option<String>,
@@ -80,7 +113,18 @@ pub async fn list(
     let server_config = config.resolve_server(server_ref)?;
     let client = RicochetClient::new(&server_config)?;
 
-    let items = client.list_items().await?;
+    let items = client.list_items(scope).await?;
+
+    // A server without the instance-wide listing ignores the unknown query
+    // parameter and answers with the ACL-scoped list, which carries no owner.
+    if scope == ItemScope::All
+        && !items.is_empty()
+        && !items.iter().any(|item| owner_label(item).is_some())
+    {
+        anyhow::bail!(
+            "This server does not support --all and returned only the items your API key has access to.\nUpgrade the server, or drop --all to list those items explicitly."
+        );
+    }
 
     // Filter items if needed
     let filtered_items: Vec<_> = items
@@ -169,7 +213,7 @@ pub async fn list(
 
             let mut table = Table::new();
             table.load_style(UTF8_FULL);
-            table.set_header(vec![
+            let mut header = vec![
                 "ID",
                 "Name",
                 "Type",
@@ -177,7 +221,11 @@ pub async fn list(
                 "Visibility",
                 "Status",
                 "Updated",
-            ]);
+            ];
+            if scope == ItemScope::All {
+                header.insert(2, "Owner");
+            }
+            table.set_header(header);
 
             for item in &filtered_items {
                 let id = item.get("id").and_then(|v| v.as_str()).unwrap_or("-");
@@ -218,7 +266,7 @@ pub async fn list(
                     _ => Cell::new(visibility),
                 };
 
-                table.add_row(vec![
+                let mut cells = vec![
                     Cell::new(id),
                     Cell::new(name),
                     Cell::new(content_type),
@@ -226,7 +274,15 @@ pub async fn list(
                     visibility_cell,
                     status_cell,
                     Cell::new(updated),
-                ]);
+                ];
+                if scope == ItemScope::All {
+                    cells.insert(
+                        2,
+                        Cell::new(owner_label(item).unwrap_or_else(|| "-".to_string())),
+                    );
+                }
+
+                table.add_row(cells);
             }
 
             println!("{}", table);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use colored::Colorize;
-use ricochet_cli::{OutputFormat, app, commands, config::Config, item, update};
+use ricochet_cli::{OutputFormat, app, client::ItemScope, commands, config::Config, item, update};
 
 // App specific methods go in `src/app/`
 // Task specific methods go in `src/task`
@@ -178,6 +178,9 @@ enum ItemCommands {
         /// Show only active deployments (status: deployed, running, or success)
         #[arg(short = 'a', long)]
         active_only: bool,
+        /// List every item on the instance, not just your own (requires an instance admin API key)
+        #[arg(long)]
+        all: bool,
         /// Sort by field(s) - comma-separated for multiple (e.g., "name,updated" or "status,name")
         /// Prefix with '-' for descending order (e.g., "-updated,name")
         #[arg(short = 's', long)]
@@ -232,6 +235,9 @@ enum TaskCommands {
         /// Show only active deployments (status: deployed, running, or success)
         #[arg(short = 'a', long)]
         active_only: bool,
+        /// List every item on the instance, not just your own (requires an instance admin API key)
+        #[arg(long)]
+        all: bool,
         /// Sort by field(s) - comma-separated for multiple (e.g., "name,updated" or "status,name")
         /// Prefix with '-' for descending order (e.g., "-updated,name")
         #[arg(short = 's', long)]
@@ -519,12 +525,18 @@ async fn main() -> Result<()> {
             ItemCommands::List {
                 content_type,
                 active_only,
+                all,
                 sort,
             } => {
                 commands::list::list(
                     &config,
                     cli.server.as_deref(),
                     commands::list::ListKind::App,
+                    if all {
+                        ItemScope::All
+                    } else {
+                        ItemScope::Owned
+                    },
                     content_type,
                     active_only,
                     sort,
@@ -661,12 +673,18 @@ async fn main() -> Result<()> {
             TaskCommands::List {
                 content_type,
                 active_only,
+                all,
                 sort,
             } => {
                 commands::list::list(
                     &config,
                     cli.server.as_deref(),
                     commands::list::ListKind::Task,
+                    if all {
+                        ItemScope::All
+                    } else {
+                        ItemScope::Owned
+                    },
                     content_type,
                     active_only,
                     sort,

--- a/tests/list_test.rs
+++ b/tests/list_test.rs
@@ -5,6 +5,7 @@ use url::Url;
 #[cfg(test)]
 mod list_tests {
     use super::*;
+    use ricochet_cli::client::ItemScope;
     use ricochet_cli::commands::list::ListKind;
 
     #[tokio::test]
@@ -53,6 +54,7 @@ mod list_tests {
             &config,
             None,
             ListKind::App,
+            ItemScope::Owned,
             None,
             false,
             None, // no sorting
@@ -100,6 +102,7 @@ mod list_tests {
             &config,
             None,
             ListKind::App,
+            ItemScope::Owned,
             None,
             false,
             None, // no sorting
@@ -159,6 +162,7 @@ mod list_tests {
             &config,
             None,
             ListKind::App,
+            ItemScope::Owned,
             Some("shiny".to_string()),
             false,
             None, // no sorting
@@ -174,6 +178,7 @@ mod list_tests {
             &config,
             None,
             ListKind::App,
+            ItemScope::Owned,
             None,
             true,
             None, // no sorting
@@ -209,6 +214,7 @@ mod list_tests {
             &config,
             None,
             ListKind::App,
+            ItemScope::Owned,
             None,
             false,
             None, // no sorting
@@ -218,6 +224,142 @@ mod list_tests {
         .await;
 
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_list_all_requests_the_instance_wide_scope() {
+        let mut server = Server::new_async().await;
+
+        let _m = server
+            .mock("GET", "/api/v0/user/items?scope=all")
+            .match_header("authorization", "Key test_api_key")
+            .with_status(200)
+            .with_body(
+                json!([
+                    {
+                        "id": "01K66JV2Q123",
+                        "name": "Shiny App",
+                        "content_type": "shiny",
+                        "language": "R",
+                        "visibility": "private",
+                        "status": "deployed",
+                        "updated_at": "2024-01-15T10:30:00Z",
+                        "owner": {"id": "01K66JV2QOWNER", "email": "someone@example.com"}
+                    }
+                ])
+                .to_string(),
+            )
+            .create();
+
+        let config = ricochet_cli::config::Config::for_test(
+            Url::parse(&server.url()).unwrap(),
+            Some("test_api_key".to_string()),
+        );
+
+        let result = ricochet_cli::commands::list::list(
+            &config,
+            None,
+            ListKind::App,
+            ItemScope::All,
+            None,
+            false,
+            None, // no sorting
+            ricochet_cli::OutputFormat::Table,
+            false,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        _m.assert();
+    }
+
+    #[tokio::test]
+    async fn test_list_all_reports_a_server_without_the_scope() {
+        let mut server = Server::new_async().await;
+
+        // A server predating the instance-wide listing ignores `scope` and
+        // answers with the ACL-scoped items, which carry no owner.
+        let _m = server
+            .mock("GET", "/api/v0/user/items?scope=all")
+            .match_header("authorization", "Key test_api_key")
+            .with_status(200)
+            .with_body(
+                json!([
+                    {
+                        "id": "01K66JV2Q123",
+                        "name": "Shiny App",
+                        "content_type": "shiny",
+                        "language": "R",
+                        "visibility": "private",
+                        "status": "deployed",
+                        "updated_at": "2024-01-15T10:30:00Z"
+                    }
+                ])
+                .to_string(),
+            )
+            .create();
+
+        let config = ricochet_cli::config::Config::for_test(
+            Url::parse(&server.url()).unwrap(),
+            Some("test_api_key".to_string()),
+        );
+
+        let result = ricochet_cli::commands::list::list(
+            &config,
+            None,
+            ListKind::App,
+            ItemScope::All,
+            None,
+            false,
+            None, // no sorting
+            ricochet_cli::OutputFormat::Table,
+            false,
+        )
+        .await;
+
+        let error = result
+            .expect_err("an unsupported --all must fail")
+            .to_string();
+        assert!(
+            error.contains("does not support --all"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_all_reports_a_non_admin_caller() {
+        let mut server = Server::new_async().await;
+
+        let _m = server
+            .mock("GET", "/api/v0/user/items?scope=all")
+            .match_header("authorization", "Key test_api_key")
+            .with_status(403)
+            .with_body(json!({"error": "admin privileges required"}).to_string())
+            .create();
+
+        let config = ricochet_cli::config::Config::for_test(
+            Url::parse(&server.url()).unwrap(),
+            Some("test_api_key".to_string()),
+        );
+
+        let result = ricochet_cli::commands::list::list(
+            &config,
+            None,
+            ListKind::App,
+            ItemScope::All,
+            None,
+            false,
+            None, // no sorting
+            ricochet_cli::OutputFormat::Table,
+            false,
+        )
+        .await;
+
+        let error = result.expect_err("a non-admin --all must fail").to_string();
+        assert!(
+            error.contains("requires an instance admin API key"),
+            "unexpected error: {error}"
+        );
     }
 }
 

--- a/tests/list_test.rs
+++ b/tests/list_test.rs
@@ -244,7 +244,11 @@ mod list_tests {
                         "visibility": "private",
                         "status": "deployed",
                         "updated_at": "2024-01-15T10:30:00Z",
-                        "owner": {"id": "01K66JV2QOWNER", "email": "someone@example.com"}
+                        "owner": {
+                            "id": "01K66JV2QOWNER",
+                            "display_name": "Ada Lovelace",
+                            "email": "ada@example.com"
+                        }
                     }
                 ])
                 .to_string(),


### PR DESCRIPTION
`ricochet app list --all` and `ricochet task list --all` now request the instance-wide listing so an instance admin can take an inventory of a server from the CLI.

<details>
<summary>AI Summary</summary>

## API contract

The flag calls `GET /api/v0/user/items?scope=all` rather than a dedicated admin endpoint, so the server reuses the existing handler and gates the scope on the admin role.
That endpoint does not exist yet: this is the CLI half of ricochet-rs/ricochet#1229, and it is written against the contract that issue proposes.

The default listing is unchanged and still sends no query parameter at all, so its request stays byte-identical to today's.

## Changes

`src/client.rs` gains an `ItemScope` enum with `Owned` and `All`, which `list_items` takes in place of a boolean.
403 handling moved off the previous string match against the formatted error and onto the response status, so `--all` reports "Listing every item on the instance requires an instance admin API key" with the server's own message appended.
The existing "Invalid API key" message is preserved.

`src/commands/list.rs` renders an `Owner` column after `Name`, only under `--all`.
`owner_label()` accepts the owner as either a string or an object, reading `email`, `username`, `name` or `id` from an object and falling back to `owner_name`, `owner_email` or `owner_id` at the top level.
`--sort owner` compares that rendered label instead of the raw JSON representation.

`src/main.rs` adds `--all` to both list subcommands, long-only because `-a` is `--active-only`.

`docs/cli-commands.md` is regenerated with `just docs`.

## Detecting a server without the endpoint

A scope parameter cannot be detected out of band.
`list_user_items` has no `Query` extractor today, so an older server ignores `scope=all` and answers `200` with the ACL-scoped list.
The only in-band signal is the owner field, which ricochet-rs/ricochet#1229 adds to the instance-wide payload alone, so `--all` fails when the response is non-empty and no item carries an owner:

```
This server does not support --all and returned only the items your API key has access to.
Upgrade the server, or drop --all to list those items explicitly.
```

An empty response is indistinguishable from a supported one, but there is nothing to mislead the reader with in that case.

## Server counterpart

ricochet-rs/ricochet#1331 implements the endpoint this calls. The owner arrives as an `owner` object carrying `display_name`, `email` and `id`, and the column prefers them in that order.

## Validation

- `just check` passes: `cargo check --all-features --workspace`, `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `just docs-check`.
- `cargo test --all-features` passes, including three new `tests/list_test.rs` cases covering the `?scope=all` request, the non-admin 403 message, and the unsupported-server message.
- `prek run -a` passes.
- Not exercised against a running server, because the endpoint is not on `ricochet` `main` yet.

</details>

Closes #186

