### PR TITLE
fix: emit only the payload on stdout under `-F json` and `-F yaml`

### DIFF
--- a/.claude/skills/ricochet-cli/SKILL.md
+++ b/.claude/skills/ricochet-cli/SKILL.md
@@ -16,6 +16,7 @@ Write `_ricochet.toml` by hand instead of calling `ricochet init` from an agent 
 Under the same conditions `ricochet deploy` fails with `No _ricochet.toml found` rather than offering to create one.
 
 Pass `-F json` to any command whose output must be parsed.
+Under `-F json` and `-F yaml` stdout carries the serialised payload and nothing else, while status lines, hints and links go to stderr.
 Pass `--debug` to surface the underlying request and response when a command fails.
 
 ## Connect to a server

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,9 @@ Legacy single-server configs are automatically migrated to multi-server format.
 ### Output Formats
 
 The CLI supports multiple output formats: `table` (default), `json`, and `yaml`.
+Under `json` and `yaml`, stdout carries the serialised payload and nothing else, so status lines, hints, prompts and links go to stderr.
+Print command output through `OutputFormat::print` in `src/output.rs`, which serialises the payload for a machine reader and defers the human rendering to a closure that returns a `String`.
+Give every new command a `format` argument and a case in `tests/json_output_test.rs`, which spawns the built binary and asserts that stdout parses as JSON.
 
 ### CI/CD
 

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -74,7 +74,7 @@ Ricochet CLI
 ###### **Options:**
 
 * `-S`, `--server <SERVER>` — Server URL (can also be set with RICOCHET_SERVER environment variable)
-* `-F`, `--format <FORMAT>` — Output format
+* `-F`, `--format <FORMAT>` — Output format. `json` and `yaml` write the payload to stdout and everything else to stderr
 
   Default value: `table`
 

--- a/src/app/instances.rs
+++ b/src/app/instances.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use colored::Colorize;
 use comfy_table::{Cell, Color, Table, presets::UTF8_FULL};
 use jiff::Timestamp;
@@ -126,18 +126,30 @@ pub async fn stop_instance(
         }
     };
 
-    for target in &targets {
-        client.stop_instance(&id, target).await?;
+    // Report what came down before surfacing a failure, so a partial stop
+    // leaves a record of which instances the caller no longer has to stop.
+    let mut succeeded = Vec::new();
+    let mut failure = None;
+    for target in targets {
+        if let Err(e) = client.stop_instance(&id, &target).await {
+            failure = Some((target, e));
+            break;
+        }
+        succeeded.push(target);
     }
 
     let stopped = StoppedInstances {
         content_id: id,
-        stopped: targets,
+        stopped: succeeded,
     };
 
     format.print(&stopped, || {
         if stopped.stopped.is_empty() {
-            return Ok("No instances to stop".yellow().to_string());
+            let message = match failure {
+                Some(_) => "No instances stopped",
+                None => "No instances to stop",
+            };
+            return Ok(message.yellow().to_string());
         }
         Ok(stopped
             .stopped
@@ -151,5 +163,10 @@ pub async fn stop_instance(
             })
             .collect::<Vec<_>>()
             .join("\n"))
-    })
+    })?;
+
+    match failure {
+        Some((target, e)) => Err(e).with_context(|| format!("stopping instance {target}")),
+        None => Ok(()),
+    }
 }

--- a/src/app/instances.rs
+++ b/src/app/instances.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use colored::Colorize;
 use comfy_table::{Cell, Color, Table, presets::UTF8_FULL};
 use jiff::Timestamp;
+use serde::Serialize;
 use std::path::Path;
 
 use crate::{OutputFormat, client::RicochetClient, config::Config, item::resolve_id, utils};
@@ -35,75 +36,67 @@ pub async fn list_instances(
         }
     }
 
-    match format {
-        OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(&instances)?);
-        }
-        OutputFormat::Yaml => {
-            println!("{}", serde_yaml::to_string(&instances)?);
-        }
-        OutputFormat::Table => {
-            println!("{}", server_config.url.as_str().italic().dimmed());
+    format.print(&instances, || {
+        let mut output = server_config.url.as_str().italic().dimmed().to_string();
 
-            let Some(arr) = instances.as_array() else {
-                println!("{}", "No instances found".yellow());
-                return Ok(());
+        let Some(arr) = instances.as_array().filter(|arr| !arr.is_empty()) else {
+            output.push_str(&format!("\n{}", "No instances found".yellow()));
+            return Ok(output);
+        };
+
+        let mut table = Table::new();
+        table.load_style(UTF8_FULL);
+        table.set_header(vec![
+            "Instance ID",
+            "Connections",
+            "Started",
+            "Last Connection",
+        ]);
+
+        for instance in arr {
+            let pid = instance
+                .get("instance_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("-");
+            let connections = instance
+                .get("connections")
+                .and_then(|v| v.as_u64())
+                .map(|n| n.to_string())
+                .unwrap_or_else(|| "-".to_string());
+            let started = instance
+                .get("created_at")
+                .and_then(|v| v.as_str())
+                .map(utils::format_timestamp)
+                .unwrap_or_else(|| "-".to_string());
+            let last_conn = instance
+                .get("last_connection")
+                .and_then(|v| v.as_str())
+                .unwrap_or("-");
+
+            let conn_cell = if connections == "0" {
+                Cell::new(&connections).fg(Color::DarkGrey)
+            } else {
+                Cell::new(&connections).fg(Color::Green)
             };
 
-            if arr.is_empty() {
-                println!("{}", "No instances found".yellow());
-                return Ok(());
-            }
-
-            let mut table = Table::new();
-            table.load_style(UTF8_FULL);
-            table.set_header(vec![
-                "Instance ID",
-                "Connections",
-                "Started",
-                "Last Connection",
+            table.add_row(vec![
+                Cell::new(pid),
+                conn_cell,
+                Cell::new(started),
+                Cell::new(last_conn),
             ]);
-
-            for instance in arr {
-                let pid = instance
-                    .get("instance_id")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-");
-                let connections = instance
-                    .get("connections")
-                    .and_then(|v| v.as_u64())
-                    .map(|n| n.to_string())
-                    .unwrap_or_else(|| "-".to_string());
-                let started = instance
-                    .get("created_at")
-                    .and_then(|v| v.as_str())
-                    .map(utils::format_timestamp)
-                    .unwrap_or_else(|| "-".to_string());
-                let last_conn = instance
-                    .get("last_connection")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-");
-
-                let conn_cell = if connections == "0" {
-                    Cell::new(&connections).fg(Color::DarkGrey)
-                } else {
-                    Cell::new(&connections).fg(Color::Green)
-                };
-
-                table.add_row(vec![
-                    Cell::new(pid),
-                    conn_cell,
-                    Cell::new(started),
-                    Cell::new(last_conn),
-                ]);
-            }
-
-            println!("{}", table);
-            println!("\n{} instance(s)", arr.len());
         }
-    }
 
-    Ok(())
+        output.push_str(&format!("\n{table}\n\n{} instance(s)", arr.len()));
+        Ok(output)
+    })
+}
+
+/// The instances a `stop` call brought down.
+#[derive(Serialize)]
+struct StoppedInstances {
+    content_id: String,
+    stopped: Vec<String>,
 }
 
 pub async fn stop_instance(
@@ -112,42 +105,51 @@ pub async fn stop_instance(
     id: Option<&str>,
     pid: Option<&str>,
     path: Option<&Path>,
+    format: OutputFormat,
 ) -> Result<()> {
     let id = resolve_id(id, path)?;
     let server_config = config.resolve_server(server_ref)?;
     let client = RicochetClient::new(&server_config)?;
     client.preflight_key_check().await?;
 
-    match pid {
-        Some(pid) => {
-            client.stop_instance(&id, pid).await?;
-            println!(
-                "{} Instance {} stopped",
-                "✓".green().bold(),
-                pid.bright_cyan()
-            );
-        }
+    let targets = match pid {
+        Some(pid) => vec![pid.to_string()],
         None => {
             let instances = client.list_instances(&id).await?;
             let arr = instances
                 .as_array()
                 .ok_or_else(|| anyhow::anyhow!("Unexpected response format"))?;
-            if arr.is_empty() {
-                println!("{}", "No instances to stop".yellow());
-                return Ok(());
-            }
-            for instance in arr.clone() {
-                if let Some(iid) = instance.get("instance_id").and_then(|v| v.as_str()) {
-                    client.stop_instance(&id, iid).await?;
-                    println!(
-                        "{} Instance {} stopped",
-                        "✓".green().bold(),
-                        iid.bright_cyan()
-                    );
-                }
-            }
+            arr.iter()
+                .filter_map(|instance| instance.get("instance_id").and_then(|v| v.as_str()))
+                .map(str::to_string)
+                .collect()
         }
+    };
+
+    for target in &targets {
+        client.stop_instance(&id, target).await?;
     }
 
-    Ok(())
+    let stopped = StoppedInstances {
+        content_id: id,
+        stopped: targets,
+    };
+
+    format.print(&stopped, || {
+        if stopped.stopped.is_empty() {
+            return Ok("No instances to stop".yellow().to_string());
+        }
+        Ok(stopped
+            .stopped
+            .iter()
+            .map(|pid| {
+                format!(
+                    "{} Instance {} stopped",
+                    "✓".green().bold(),
+                    pid.bright_cyan()
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n"))
+    })
 }

--- a/src/commands/auth/auth_unit_test.rs
+++ b/src/commands/auth/auth_unit_test.rs
@@ -28,7 +28,7 @@ mod tests {
         }
 
         // Call logout with no server specified (uses default)
-        let result = super::super::logout(&mut config, None);
+        let result = super::super::logout(&mut config, None, crate::OutputFormat::Table);
 
         assert!(result.is_ok(), "Logout should succeed");
         // Check that the default server's API key is cleared
@@ -55,7 +55,7 @@ mod tests {
         }
 
         // Call logout when already logged out
-        let result = super::super::logout(&mut config, None);
+        let result = super::super::logout(&mut config, None, crate::OutputFormat::Table);
 
         assert!(
             result.is_ok(),
@@ -291,7 +291,7 @@ mod tests {
         assert!(config.servers.get("staging").unwrap().api_key.is_some());
 
         // Logout from staging (not the default)
-        let result = super::super::logout(&mut config, Some("staging"));
+        let result = super::super::logout(&mut config, Some("staging"), crate::OutputFormat::Table);
 
         assert!(result.is_ok());
 
@@ -312,7 +312,11 @@ mod tests {
         let mut config = create_multi_server_config();
 
         // Logout using URL
-        let result = super::super::logout(&mut config, Some("https://staging.ricochet.com"));
+        let result = super::super::logout(
+            &mut config,
+            Some("https://staging.ricochet.com"),
+            crate::OutputFormat::Table,
+        );
 
         assert!(result.is_ok());
 
@@ -328,7 +332,8 @@ mod tests {
         let _temp_dir = setup_test_env();
         let mut config = create_multi_server_config();
 
-        let result = super::super::logout(&mut config, Some("nonexistent"));
+        let result =
+            super::super::logout(&mut config, Some("nonexistent"), crate::OutputFormat::Table);
 
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
@@ -341,7 +346,11 @@ mod tests {
         let _temp_dir = setup_test_env();
         let mut config = create_multi_server_config();
 
-        let result = super::super::logout(&mut config, Some("https://unknown.server.com"));
+        let result = super::super::logout(
+            &mut config,
+            Some("https://unknown.server.com"),
+            crate::OutputFormat::Table,
+        );
 
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("No server found"));
@@ -358,7 +367,7 @@ mod tests {
         assert!(config.servers.get("prod").unwrap().api_key.is_some());
 
         // Logout without specifying server
-        let result = super::super::logout(&mut config, None);
+        let result = super::super::logout(&mut config, None, crate::OutputFormat::Table);
 
         assert!(result.is_ok());
 
@@ -379,7 +388,7 @@ mod tests {
         let mut config = create_multi_server_config();
 
         // local has no API key
-        let result = super::super::logout(&mut config, Some("local"));
+        let result = super::super::logout(&mut config, Some("local"), crate::OutputFormat::Table);
 
         // Should succeed without error (just a warning)
         assert!(result.is_ok());

--- a/src/commands/auth/login.rs
+++ b/src/commands/auth/login.rs
@@ -1,5 +1,5 @@
 use super::auth_ui;
-use crate::{client::RicochetClient, config::Config};
+use crate::{OutputFormat, client::RicochetClient, commands::server::mask_api_key, config::Config};
 use anyhow::Result;
 use colored::Colorize;
 use dialoguer::Password;
@@ -33,6 +33,22 @@ pub(crate) struct CreateApiKeyRequest {
     pub(crate) expires_at: Option<String>, // Alternative: ISO 8601 timestamp
 }
 
+/// The credentials a login stored.
+#[derive(Serialize)]
+struct LoginResult {
+    server: String,
+    url: String,
+    api_key: Option<String>,
+    expires_at: Option<String>,
+}
+
+/// The credentials a logout cleared.
+#[derive(Serialize)]
+struct LogoutResult {
+    server: String,
+    logged_out: bool,
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub(crate) struct ApiKeyResponse {
     pub(crate) key: String,
@@ -46,24 +62,25 @@ pub async fn login(
     config: &mut Config,
     server_ref: Option<&str>,
     api_key: Option<String>,
+    format: OutputFormat,
 ) -> Result<()> {
-    println!("🔐 Authenticating against Ricochet server\n");
+    eprintln!("🔐 Authenticating against Ricochet server\n");
 
     // Resolve which server to authenticate with
     let (server_url, server_name, server_source) = resolve_login_server(config, server_ref)?;
 
-    println!("Server: {}", server_url.as_str().bright_cyan());
+    eprintln!("Server: {}", server_url.as_str().bright_cyan());
     if let Some(ref name) = server_name {
-        println!("Profile: {}", name.bright_cyan());
+        eprintln!("Profile: {}", name.bright_cyan());
     }
     if server_source == LoginServerSource::HostedTrialFallback {
-        println!("{}", "Using the hosted trial default.".dimmed());
-        println!(
+        eprintln!("{}", "Using the hosted trial default.".dimmed());
+        eprintln!(
             "{}",
             "Register your own server with `ricochet server add <NAME> <URL>`.".dimmed()
         );
     }
-    println!();
+    eprintln!();
 
     // Check if already authenticated with this server
     let server_config = config.resolve_server(server_ref).ok();
@@ -72,17 +89,24 @@ pub async fn login(
     {
         let client = RicochetClient::new_with_key(server_url.to_string(), existing_key.clone())?;
         if client.validate_key().await.unwrap_or(false) {
-            println!(
-                "{} Already authenticated",
-                symbols::check_mark().to_string().green().bold()
-            );
-            println!(
+            eprintln!(
                 "{}",
                 "Note: Ensure your API key hasn't expired (CLI keys expire after 8 hours)".dimmed()
             );
-            return Ok(());
+            let result = LoginResult {
+                server: determine_server_name(config, &server_url, server_name),
+                url: server_url.to_string(),
+                api_key: Some(mask_api_key(existing_key)),
+                expires_at: None,
+            };
+            return format.print(&result, || {
+                Ok(format!(
+                    "{} Already authenticated",
+                    symbols::check_mark().to_string().green().bold()
+                ))
+            });
         } else {
-            println!(
+            eprintln!(
                 "{} Existing credentials are invalid or expired, proceeding with login...",
                 "⚠".yellow()
             );
@@ -97,27 +121,29 @@ pub async fn login(
             key,
             server_name.clone(),
             server_source,
+            format,
         )
         .await;
     }
 
     // In headless environments, prompt for manual API key entry instead of OAuth
     if is_headless() {
-        println!(
+        eprintln!(
             "{} Headless environment detected (no display server). Using manual key entry.",
             "ℹ".bright_cyan()
         );
-        println!("Create an API key in your server's web UI and paste it below.\n");
+        eprintln!("Create an API key in your server's web UI and paste it below.\n");
 
         let key = Password::new()
             .with_prompt("Enter API key (starts with 'rico_')")
             .interact()?;
 
-        return validate_and_save_key(config, server_url, key, server_name, server_source).await;
+        return validate_and_save_key(config, server_url, key, server_name, server_source, format)
+            .await;
     }
 
     // Use OAuth with local callback server
-    oauth_login_with_callback(config, server_url, server_name, server_source).await?;
+    oauth_login_with_callback(config, server_url, server_name, server_source, format).await?;
 
     Ok(())
 }
@@ -189,12 +215,13 @@ async fn oauth_login_with_callback(
     server: url::Url,
     server_name: Option<String>,
     server_source: LoginServerSource,
+    format: OutputFormat,
 ) -> Result<()> {
     use axum::{Router, extract::Query, response::Html, routing::get};
     use std::collections::HashMap;
     use tokio::net::TcpListener;
 
-    println!("\n{}", "Starting OAuth authentication...".yellow());
+    eprintln!("\n{}", "Starting OAuth authentication...".yellow());
 
     // Find an available port
     let listener = TcpListener::bind("127.0.0.1:0").await?;
@@ -226,7 +253,7 @@ async fn oauth_login_with_callback(
                     {
                         *api_key = format!("{}...", &api_key[..12]);
                     }
-                    println!("Received callback with params: {:?}", debug_params);
+                    eprintln!("Received callback with params: {:?}", debug_params);
                 }
 
                 if let Some(error) = params.get("error") {
@@ -245,7 +272,7 @@ async fn oauth_login_with_callback(
                     Html(auth_ui::create_session_page())
                 } else {
                     // Log all params for debugging
-                    println!("Callback params: {:?}", params);
+                    eprintln!("Callback params: {:?}", params);
                     auth_state.received_callback = true;
                     // Use a simple complete page from auth_ui
                     Html(auth_ui::create_session_page())
@@ -266,17 +293,17 @@ async fn oauth_login_with_callback(
         .append_pair("response_type", "code")
         .append_pair("client_id", "cli");
 
-    println!("\nOpening browser for authentication...");
-    println!("If browser doesn't open, visit:");
-    println!("  {}", oauth_url.to_string().bright_cyan().underline());
+    eprintln!("\nOpening browser for authentication...");
+    eprintln!("If browser doesn't open, visit:");
+    eprintln!("  {}", oauth_url.to_string().bright_cyan().underline());
 
     // Open browser
     if webbrowser::open(oauth_url.as_str()).is_err() {
-        println!("\n{}", "Could not open browser automatically".dimmed());
+        eprintln!("\n{}", "Could not open browser automatically".dimmed());
     }
 
     // Wait for callback (with timeout)
-    println!("\nWaiting for authentication...");
+    eprintln!("\nWaiting for authentication...");
     let timeout = tokio::time::Duration::from_secs(300); // 5 minutes
     let start = tokio::time::Instant::now();
 
@@ -308,7 +335,7 @@ async fn oauth_login_with_callback(
         // Check if it's an API key (starts with rico_) or session token
         if token.starts_with("rico_") {
             // Direct API key - just save it!
-            println!(
+            eprintln!(
                 "\n{} Received API key directly from server!",
                 symbols::check_mark().to_string().green().bold()
             );
@@ -318,6 +345,7 @@ async fn oauth_login_with_callback(
                 token.clone(),
                 server_name.clone(),
                 server_source,
+                format,
             )
             .await?;
         } else {
@@ -328,28 +356,29 @@ async fn oauth_login_with_callback(
                 token.clone(),
                 server_name.clone(),
                 server_source,
+                format,
             )
             .await?;
         }
     } else {
         // Fall back to manual entry
-        println!(
+        eprintln!(
             "\n{}",
             "OAuth callback received but no session token provided".yellow()
         );
-        println!("Please create an API key manually in the browser");
+        eprintln!("Please create an API key manually in the browser");
 
         let mut keys_url = server.clone();
         keys_url.set_path("/credentials");
         if webbrowser::open(keys_url.as_str()).is_err() {
-            println!("Open: {}", keys_url.as_str().bright_cyan().underline());
+            eprintln!("Open: {}", keys_url.as_str().bright_cyan().underline());
         }
 
         let key = Password::new()
             .with_prompt("Enter API key (starts with 'rico_')")
             .interact()?;
 
-        validate_and_save_key(config, server, key, server_name, server_source).await?;
+        validate_and_save_key(config, server, key, server_name, server_source, format).await?;
     }
 
     Ok(())
@@ -361,8 +390,9 @@ async fn create_api_key_with_session(
     session_token: String,
     server_name: Option<String>,
     server_source: LoginServerSource,
+    format: OutputFormat,
 ) -> Result<()> {
-    println!("\n{}", "Creating API key using session...".dimmed());
+    eprintln!("\n{}", "Creating API key using session...".dimmed());
 
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(10))
@@ -402,16 +432,6 @@ async fn create_api_key_with_session(
         )?;
         config.save()?;
 
-        println!(
-            "\n{} Successfully created and saved API key!",
-            symbols::check_mark().to_string().green().bold()
-        );
-        println!(
-            "Server: {} ({})",
-            name.bright_cyan(),
-            server.as_str().dimmed()
-        );
-
         // Display expiration info
         if let Some(expires_at) = &api_key_data.expires_at {
             if let Ok(expiry_time) = chrono::DateTime::parse_from_rfc3339(expires_at) {
@@ -422,34 +442,42 @@ async fn create_api_key_with_session(
                     let hours = duration.num_hours();
                     let minutes = (duration.num_minutes() % 60).abs();
 
-                    println!(
+                    eprintln!(
                         "API key expires in: {} hours {} minutes",
                         hours.to_string().bright_yellow(),
                         minutes.to_string().bright_yellow()
                     );
                 }
-                println!(
+                eprintln!(
                     "Expires at: {}",
                     expiry_time.format("%Y-%m-%d %H:%M:%S UTC")
                 );
             }
         } else {
-            println!("API key expires in: 8 hours");
+            eprintln!("API key expires in: 8 hours");
         }
 
-        println!(
+        eprintln!(
             "Configuration saved to: {}",
             Config::config_path()?.display()
         );
 
-        // Show the key prefix for verification
-        let key_prefix = if api_key_data.key.len() > 12 {
-            &api_key_data.key[..12]
-        } else {
-            &api_key_data.key
+        let result = LoginResult {
+            server: name,
+            url: server.to_string(),
+            api_key: Some(mask_api_key(&api_key_data.key)),
+            expires_at: api_key_data.expires_at.clone(),
         };
-        println!("API key: {}...", key_prefix.dimmed());
-        Ok(())
+
+        format.print(&result, || {
+            Ok(format!(
+                "\n{} Successfully created and saved API key!\nServer: {} ({})\nAPI key: {}",
+                symbols::check_mark().to_string().green().bold(),
+                result.server.bright_cyan(),
+                server.as_str().dimmed(),
+                result.api_key.as_deref().unwrap_or("").dimmed()
+            ))
+        })
     } else {
         anyhow::bail!("Failed to create API key. Session may be invalid or expired.")
     }
@@ -525,8 +553,9 @@ async fn validate_and_save_key(
     key: String,
     server_name: Option<String>,
     server_source: LoginServerSource,
+    format: OutputFormat,
 ) -> Result<()> {
-    println!("\n{}", "Validating credentials...".dimmed());
+    eprintln!("\n{}", "Validating credentials...".dimmed());
     let client = RicochetClient::new_with_key(server.to_string(), key.clone())?;
 
     match client.validate_key().await {
@@ -535,24 +564,27 @@ async fn validate_and_save_key(
                 store_login_credentials(config, &server, key.clone(), server_name, server_source)?;
             config.save()?;
 
-            println!(
-                "\n{} Successfully authenticated!",
-                symbols::check_mark().to_string().green().bold()
-            );
-            println!(
-                "Server: {} ({})",
-                name.bright_cyan(),
-                server.as_str().dimmed()
-            );
-            println!(
+            eprintln!(
                 "Configuration saved to: {}",
                 Config::config_path()?.display()
             );
 
-            // Show the key prefix for verification
-            let key_prefix = if key.len() > 12 { &key[..12] } else { &key };
-            println!("API key: {}...", key_prefix.dimmed());
-            Ok(())
+            let result = LoginResult {
+                server: name,
+                url: server.to_string(),
+                api_key: Some(mask_api_key(&key)),
+                expires_at: None,
+            };
+
+            format.print(&result, || {
+                Ok(format!(
+                    "\n{} Successfully authenticated!\nServer: {} ({})\nAPI key: {}",
+                    symbols::check_mark().to_string().green().bold(),
+                    result.server.bright_cyan(),
+                    server.as_str().dimmed(),
+                    result.api_key.as_deref().unwrap_or("").dimmed()
+                ))
+            })
         }
         Ok(false) => {
             anyhow::bail!("Invalid API key. Please check and try again.")
@@ -563,7 +595,7 @@ async fn validate_and_save_key(
     }
 }
 
-pub fn logout(config: &mut Config, server_ref: Option<&str>) -> Result<()> {
+pub fn logout(config: &mut Config, server_ref: Option<&str>, format: OutputFormat) -> Result<()> {
     // Resolve which server to logout from
     let server_name = if let Some(ref_str) = server_ref {
         // Check if it's a named server
@@ -598,24 +630,35 @@ pub fn logout(config: &mut Config, server_ref: Option<&str>) -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("Server '{}' not found", server_name))?;
 
     if server_config.api_key.is_none() {
-        println!(
-            "{} Not logged in to server '{}'",
-            "⚠".yellow(),
-            server_name.bright_cyan()
-        );
-        return Ok(());
+        let result = LogoutResult {
+            server: server_name,
+            logged_out: false,
+        };
+        return format.print(&result, || {
+            Ok(format!(
+                "{} Not logged in to server '{}'",
+                "⚠".yellow(),
+                result.server.bright_cyan()
+            ))
+        });
     }
 
     // Clear the API key
     server_config.api_key = None;
     config.save()?;
 
-    println!(
-        "{} Logged out from server '{}'",
-        symbols::check_mark().to_string().green().bold(),
-        server_name.bright_cyan()
-    );
-    Ok(())
+    let result = LogoutResult {
+        server: server_name,
+        logged_out: true,
+    };
+
+    format.print(&result, || {
+        Ok(format!(
+            "{} Logged out from server '{}'",
+            symbols::check_mark().to_string().green().bold(),
+            result.server.bright_cyan()
+        ))
+    })
 }
 
 #[cfg(test)]

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,87 +1,119 @@
-use crate::config::Config;
+use crate::{
+    OutputFormat,
+    commands::server::{ConfiguredServer, configured_servers, mask_api_key},
+    config::Config,
+};
 use anyhow::Result;
 use colored::Colorize;
+use serde::Serialize;
 
-pub fn show(config: &Config, show_all: bool) -> Result<()> {
-    println!("⚙️  {}\n", "Ricochet CLI Configuration".bold());
+/// The environment variables that override the stored configuration.
+#[derive(Serialize)]
+struct EnvironmentOverrides {
+    ricochet_server: Option<String>,
+    ricochet_api_key: Option<String>,
+}
 
-    println!("Config file: {}", Config::config_path()?.display());
-    println!();
+/// The effective CLI configuration.
+#[derive(Serialize)]
+struct ConfigView {
+    config_file: String,
+    default_server: Option<String>,
+    default_format: Option<String>,
+    servers: Vec<ConfiguredServer>,
+    environment: EnvironmentOverrides,
+}
 
-    // Show default server
-    if let Some(default_name) = config.default_server() {
-        println!("Default server: {}", default_name.bright_cyan());
+/// Reveal the key in full when the caller asked for it, otherwise mask it.
+fn shown_api_key(api_key: String, show_all: bool) -> String {
+    if show_all {
+        api_key
     } else {
-        println!("Default server: {}", "Not set".yellow());
+        mask_api_key(&api_key)
     }
+}
 
-    if let Some(format) = &config.default_format {
-        println!("Default format: {}", format);
-    }
-
-    // Show configured servers
-    println!("\n{}", "Configured Servers:".bold());
-
-    let servers = config.list_servers();
-    if servers.is_empty() {
-        println!("  {}", "None".dimmed());
-    } else {
-        let default_name = config.default_server();
-        let mut sorted_servers: Vec<_> = servers.into_iter().collect();
-        sorted_servers.sort_by(|a, b| a.0.cmp(b.0));
-
-        for (name, server_config) in sorted_servers {
-            let is_default = default_name == Some(name.as_str());
-            let marker = if is_default { " (default)" } else { "" };
-
-            println!("\n  {}{}", name.bright_cyan(), marker.dimmed());
-            println!("    URL: {}", server_config.url.as_str());
-
-            if let Some(api_key) = &server_config.api_key {
-                if show_all {
-                    println!("    API Key: {}", api_key.bright_cyan());
-                } else {
-                    let masked = if api_key.starts_with("rico_") && api_key.len() > 10 {
-                        format!("{}...{}", &api_key[..8], &api_key[api_key.len() - 4..])
-                    } else {
-                        "***hidden***".to_string()
-                    };
-                    println!("    API Key: {}", masked);
-                }
-            } else {
-                println!("    API Key: {}", "Not configured".yellow());
+pub fn show(config: &Config, show_all: bool, format: OutputFormat) -> Result<()> {
+    let mut servers = configured_servers(config);
+    if show_all {
+        for server in &mut servers {
+            if let Some(api_key) = config
+                .servers
+                .get(&server.name)
+                .and_then(|c| c.api_key.clone())
+            {
+                server.api_key = Some(api_key);
             }
         }
     }
 
-    println!("\n{}", "Environment Variables:".bold());
+    let view = ConfigView {
+        config_file: Config::config_path()?.display().to_string(),
+        default_server: config.default_server().map(str::to_string),
+        default_format: config.default_format.clone(),
+        servers,
+        environment: EnvironmentOverrides {
+            ricochet_server: std::env::var("RICOCHET_SERVER").ok(),
+            ricochet_api_key: std::env::var("RICOCHET_API_KEY")
+                .ok()
+                .map(|key| shown_api_key(key, show_all)),
+        },
+    };
 
-    if let Ok(server_env) = std::env::var("RICOCHET_SERVER") {
-        println!(
-            "  RICOCHET_SERVER: {} {}",
-            server_env.bright_cyan(),
-            "(overrides default)".dimmed()
-        );
-    } else {
-        println!("  RICOCHET_SERVER: {}", "Not set".dimmed());
-    }
+    format.print(&view, || {
+        let mut output = format!("⚙️  {}\n", "Ricochet CLI Configuration".bold());
+        output.push_str(&format!("\nConfig file: {}\n", view.config_file));
 
-    if std::env::var("RICOCHET_API_KEY").is_ok() {
-        if show_all {
-            println!(
-                "  RICOCHET_API_KEY: {}",
-                std::env::var("RICOCHET_API_KEY").unwrap().bright_cyan()
-            );
+        match &view.default_server {
+            Some(name) => output.push_str(&format!("\nDefault server: {}", name.bright_cyan())),
+            None => output.push_str(&format!("\nDefault server: {}", "Not set".yellow())),
+        }
+
+        if let Some(format) = &view.default_format {
+            output.push_str(&format!("\nDefault format: {format}"));
+        }
+
+        output.push_str(&format!("\n\n{}", "Configured Servers:".bold()));
+
+        if view.servers.is_empty() {
+            output.push_str(&format!("\n  {}", "None".dimmed()));
         } else {
-            println!(
-                "  RICOCHET_API_KEY: {} {}",
+            for server in &view.servers {
+                let marker = if server.default { " (default)" } else { "" };
+                output.push_str(&format!(
+                    "\n\n  {}{}\n    URL: {}\n    API Key: {}",
+                    server.name.bright_cyan(),
+                    marker.dimmed(),
+                    server.url,
+                    match &server.api_key {
+                        Some(api_key) => api_key.bright_cyan().to_string(),
+                        None => "Not configured".yellow().to_string(),
+                    }
+                ));
+            }
+        }
+
+        output.push_str(&format!("\n\n{}", "Environment Variables:".bold()));
+        match &view.environment.ricochet_server {
+            Some(server) => output.push_str(&format!(
+                "\n  RICOCHET_SERVER: {} {}",
+                server.bright_cyan(),
+                "(overrides default)".dimmed()
+            )),
+            None => output.push_str(&format!("\n  RICOCHET_SERVER: {}", "Not set".dimmed())),
+        }
+        match &view.environment.ricochet_api_key {
+            Some(api_key) if show_all => {
+                output.push_str(&format!("\n  RICOCHET_API_KEY: {}", api_key.bright_cyan()))
+            }
+            Some(_) => output.push_str(&format!(
+                "\n  RICOCHET_API_KEY: {} {}",
                 "***set***".green(),
                 "(overrides all server keys)".dimmed()
-            );
+            )),
+            None => output.push_str(&format!("\n  RICOCHET_API_KEY: {}", "Not set".dimmed())),
         }
-    } else {
-        println!("  RICOCHET_API_KEY: {}", "Not set".dimmed());
-    }
 
-    Ok(())
+        Ok(output)
+    })
 }

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -1,22 +1,30 @@
-use crate::{client::RicochetClient, config::Config, utils};
+use crate::{OutputFormat, client::RicochetClient, config::Config, utils};
 use anyhow::Result;
 use colored::Colorize;
+use serde::Serialize;
+
+/// The content item a `delete` call removed.
+#[derive(Serialize)]
+struct DeletedItem {
+    id: String,
+}
 
 pub async fn delete(
     config: &Config,
     server_ref: Option<&str>,
     id: &str,
     force: bool,
+    format: OutputFormat,
 ) -> Result<()> {
     if !force {
-        let message = format!("Are you sure you want to delete content item '{}'?", id);
+        let message = format!("Are you sure you want to delete content item '{id}'?");
         if !utils::confirm(&message)? {
-            println!("{}", "Deletion cancelled".yellow());
+            eprintln!("{}", "Deletion cancelled".yellow());
             return Ok(());
         }
     }
 
-    println!("🗑  Deleting content item: {}", id.bright_cyan());
+    eprintln!("🗑  Deleting content item: {}", id.bright_cyan());
 
     // Resolve server configuration
     let server_config = config.resolve_server(server_ref)?;
@@ -24,8 +32,13 @@ pub async fn delete(
 
     match client.delete(id).await {
         Ok(()) => {
-            println!("{} Content item deleted successfully!", "✓".green().bold());
-            Ok(())
+            let deleted = DeletedItem { id: id.to_string() };
+            format.print(&deleted, || {
+                Ok(format!(
+                    "{} Content item deleted successfully!",
+                    "✓".green().bold()
+                ))
+            })
         }
         Err(e) => {
             anyhow::bail!("Failed to delete content item: {}", e)

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1,4 +1,4 @@
-use crate::{client::RicochetClient, config::Config};
+use crate::{OutputFormat, client::RicochetClient, config::Config};
 use anyhow::{Result, bail};
 use colored::Colorize;
 use dialoguer::{Confirm, theme::ColorfulTheme};
@@ -6,6 +6,27 @@ use indicatif::{ProgressBar, ProgressStyle};
 use ricochet_core::{config::git::GitRepo, content::ContentItem, language::Package};
 use std::path::PathBuf;
 
+/// Record the ID the server assigned to a new content item in its `_ricochet.toml`.
+fn write_content_id(toml_path: &std::path::Path, id: &str) -> Result<()> {
+    use regex::Regex;
+
+    let original = std::fs::read_to_string(toml_path)?;
+    let updated = if original.contains("id =") {
+        Regex::new(r#"(?m)^(\s*)id\s*=\s*.*$"#)?
+            .replace(&original, format!("${{1}}id = \"{id}\""))
+            .to_string()
+    } else {
+        // FIXME: use toml-edit here
+        Regex::new(r#"(?m)^\[content\]$"#)?
+            .replace(&original, format!("[content]\nid = \"{id}\""))
+            .to_string()
+    };
+
+    std::fs::write(toml_path, updated)?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
 pub async fn deploy(
     config: &Config,
     server_ref: Option<&str>,
@@ -13,6 +34,7 @@ pub async fn deploy(
     _name: Option<String>,
     _description: Option<String>,
     env: Vec<String>,
+    format: OutputFormat,
     debug: bool,
 ) -> Result<()> {
     if !path.exists() {
@@ -75,7 +97,7 @@ pub async fn deploy(
         if let Package::UvLock = pkgs {
             // uv workspaces keep uv.lock at the workspace root — search parent dirs
             if let Some(found) = crate::utils::find_in_parent_dirs(&path, "uv.lock") {
-                println!(
+                eprintln!(
                     "  {} Using {} from workspace root",
                     "→".bright_cyan(),
                     found.display().to_string().bright_cyan()
@@ -107,7 +129,7 @@ pub async fn deploy(
         && !path.join(".python-version").exists()
     {
         if let Some(found) = crate::utils::find_in_parent_dirs(&path, ".python-version") {
-            println!(
+            eprintln!(
                 "  {} Using {} from workspace root",
                 "→".bright_cyan(),
                 found.display().to_string().bright_cyan()
@@ -119,12 +141,12 @@ pub async fn deploy(
     }
 
     if let Some(ref id) = content_id {
-        println!(
+        eprintln!(
             "📦 Creating new deployment for content item: {}\n",
             id.bright_cyan()
         );
     } else {
-        println!(
+        eprintln!(
             "📦 Deploying new {} content item\n",
             content_type.to_string().bright_cyan()
         );
@@ -163,55 +185,39 @@ pub async fn deploy(
         Ok(response) => {
             pb.finish_and_clear();
 
-            if let Some(id) = response.get("id").and_then(|v| v.as_str()) {
-                println!("{} Deployment successful!", "✓".green().bold());
+            let id = response.get("id").and_then(|v| v.as_str());
 
-                // Update _ricochet.toml with the content ID if it's a new deployment
-                if content_id.is_none() {
-                    // Read the original file content
-                    let original_content = std::fs::read_to_string(&toml_path)?;
+            // A new content item only learns its ID here, so write it back.
+            if let Some(id) = id
+                && content_id.is_none()
+            {
+                write_content_id(&toml_path, id)?;
+            }
 
-                    // Find the [content] section and add/update the id field
-                    let updated_content = if original_content.contains("id =") {
-                        // Replace existing id field
-                        use regex::Regex;
-                        let re = Regex::new(r#"(?m)^(\s*)id\s*=\s*.*$"#)?;
-                        re.replace(&original_content, format!("${{1}}id = \"{}\"", id))
-                            .to_string()
-                    } else {
-                        // FIXME: use toml-edit here
-                        // Add id field after [content] section
-                        use regex::Regex;
-                        let re = Regex::new(r#"(?m)^\[content\]$"#)?;
-                        re.replace(&original_content, format!("[content]\nid = \"{}\"", id))
-                            .to_string()
-                    };
+            format.print(&response, || {
+                let mut output = format!("{} Deployment successful!", "✓".green().bold());
 
-                    std::fs::write(&toml_path, updated_content)?;
-                }
+                let Some(id) = id else {
+                    output.push_str(&format!("\n\n{}", serde_json::to_string_pretty(&response)?));
+                    return Ok(output);
+                };
 
-                // Get server URL and construct links
                 let base_url = server_config.url.as_str().trim_end_matches('/');
+                output.push_str(&format!("\n\n{}", "Links:".bold()));
 
-                println!("\n{}", "Links:".bold());
-
-                // Show deployment link if deployment_id is available
                 if let Some(deployment_id) = response
                     .get("deployment_id")
                     .or_else(|| response.get("deploymentId"))
                     .and_then(|v| v.as_str())
                 {
-                    println!("  Deployment: {}/deployments/{}", base_url, deployment_id);
+                    output.push_str(&format!(
+                        "\n  Deployment: {base_url}/deployments/{deployment_id}"
+                    ));
                 }
 
-                // Show app overview link
-                println!("  App Overview: {}/apps/{}/overview", base_url, id);
-            } else {
-                println!("{} Deployment successful!", "✓".green().bold());
-                println!("\n{}", serde_json::to_string_pretty(&response)?);
-            }
-
-            Ok(())
+                output.push_str(&format!("\n  App Overview: {base_url}/apps/{id}/overview"));
+                Ok(output)
+            })
         }
         Err(e) => {
             pb.finish_and_clear();
@@ -272,6 +278,7 @@ pub async fn deploy_git(
     repo_path: Option<String>,
     config_path: Option<PathBuf>,
     credential: Option<String>,
+    format: OutputFormat,
 ) -> Result<()> {
     let server_config = config.resolve_server(server_ref)?;
     let client = RicochetClient::new(&server_config)?;
@@ -288,7 +295,7 @@ pub async fn deploy_git(
         None => None,
     };
 
-    println!(
+    eprintln!(
         "📦 Deploying Git-backed content item from {}\n",
         repo.url.bright_cyan()
     );
@@ -302,17 +309,24 @@ pub async fn deploy_git(
         Ok(response) => {
             pb.finish_and_clear();
 
-            println!("{} Deployment successful!", "✓".green().bold());
+            format.print(&response, || {
+                let mut output = format!("{} Deployment successful!", "✓".green().bold());
 
-            if let Some(id) = response.get("id").and_then(|v| v.as_str()) {
-                let base_url = server_config.url.as_str().trim_end_matches('/');
-                println!("\n{}", "Links:".bold());
-                println!("  App Overview: {}/apps/{}/overview", base_url, id);
-            } else {
-                println!("\n{}", serde_json::to_string_pretty(&response)?);
-            }
-
-            Ok(())
+                match response.get("id").and_then(|v| v.as_str()) {
+                    Some(id) => {
+                        let base_url = server_config.url.as_str().trim_end_matches('/');
+                        output.push_str(&format!(
+                            "\n\n{}\n  App Overview: {base_url}/apps/{id}/overview",
+                            "Links:".bold()
+                        ));
+                    }
+                    None => {
+                        output
+                            .push_str(&format!("\n\n{}", serde_json::to_string_pretty(&response)?));
+                    }
+                }
+                Ok(output)
+            })
         }
         Err(e) => {
             pb.finish_and_clear();

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -151,92 +151,82 @@ pub async fn list(
 
     let filtered_items = sorted_items;
 
-    match format {
-        OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(&filtered_items)?);
-        }
-        OutputFormat::Yaml => {
-            println!("{}", serde_yaml::to_string(&filtered_items)?);
-        }
-        OutputFormat::Table => {
-            // Display server URL above the table
-            println!("{}", server_config.url.as_str().italic().dimmed());
+    format.print(&filtered_items, || {
+        // The server URL heads the human table.
+        let mut output = server_config.url.as_str().italic().dimmed().to_string();
 
-            if filtered_items.is_empty() {
-                println!("{}", "No content items found".yellow());
-                return Ok(());
-            }
+        if filtered_items.is_empty() {
+            output.push_str(&format!("\n{}", "No content items found".yellow()));
+            return Ok(output);
+        }
 
-            let mut table = Table::new();
-            table.load_style(UTF8_FULL);
-            table.set_header(vec![
-                "ID",
-                "Name",
-                "Type",
-                "Language",
-                "Visibility",
-                "Status",
-                "Updated",
+        let mut table = Table::new();
+        table.load_style(UTF8_FULL);
+        table.set_header(vec![
+            "ID",
+            "Name",
+            "Type",
+            "Language",
+            "Visibility",
+            "Status",
+            "Updated",
+        ]);
+
+        for item in &filtered_items {
+            let id = item.get("id").and_then(|v| v.as_str()).unwrap_or("-");
+            let name = item.get("name").and_then(|v| v.as_str()).unwrap_or("-");
+            let content_type = item
+                .get("content_type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("-");
+            let language = item.get("language").and_then(|v| v.as_str()).unwrap_or("-");
+            let visibility = item
+                .get("visibility")
+                .and_then(|v| v.as_str())
+                .unwrap_or("private");
+            // Try multiple possible status field names
+            let status = item
+                .get("status")
+                .or_else(|| item.get("deployment_status"))
+                .or_else(|| item.get("last_deployment_status"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("-");
+            let updated = item
+                .get("updated_at")
+                .and_then(|v| v.as_str())
+                .map(utils::format_timestamp)
+                .unwrap_or("-".to_string());
+
+            // Create cells with proper coloring using comfy-table's Cell type
+            let status_cell = match status {
+                "deployed" | "running" | "success" => Cell::new(status).fg(Color::Green),
+                "failed" | "failure" | "error" => Cell::new(status).fg(Color::Red),
+                "stopped" | "stopping" => Cell::new(status).fg(Color::Yellow),
+                _ => Cell::new(status),
+            };
+
+            let visibility_cell = match visibility {
+                "public" => Cell::new(visibility).fg(Color::Green),
+                "private" => Cell::new(visibility).fg(Color::Blue),
+                _ => Cell::new(visibility),
+            };
+
+            table.add_row(vec![
+                Cell::new(id),
+                Cell::new(name),
+                Cell::new(content_type),
+                Cell::new(language),
+                visibility_cell,
+                status_cell,
+                Cell::new(updated),
             ]);
-
-            for item in &filtered_items {
-                let id = item.get("id").and_then(|v| v.as_str()).unwrap_or("-");
-                let name = item.get("name").and_then(|v| v.as_str()).unwrap_or("-");
-                let content_type = item
-                    .get("content_type")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-");
-                let language = item.get("language").and_then(|v| v.as_str()).unwrap_or("-");
-                let visibility = item
-                    .get("visibility")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("private");
-                // Try multiple possible status field names
-                let status = item
-                    .get("status")
-                    .or_else(|| item.get("deployment_status"))
-                    .or_else(|| item.get("last_deployment_status"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-");
-                let updated = item
-                    .get("updated_at")
-                    .and_then(|v| v.as_str())
-                    .map(utils::format_timestamp)
-                    .unwrap_or("-".to_string());
-
-                // Create cells with proper coloring using comfy-table's Cell type
-                let status_cell = match status {
-                    "deployed" | "running" | "success" => Cell::new(status).fg(Color::Green),
-                    "failed" | "failure" | "error" => Cell::new(status).fg(Color::Red),
-                    "stopped" | "stopping" => Cell::new(status).fg(Color::Yellow),
-                    _ => Cell::new(status),
-                };
-
-                let visibility_cell = match visibility {
-                    "public" => Cell::new(visibility).fg(Color::Green),
-                    "private" => Cell::new(visibility).fg(Color::Blue),
-                    _ => Cell::new(visibility),
-                };
-
-                table.add_row(vec![
-                    Cell::new(id),
-                    Cell::new(name),
-                    Cell::new(content_type),
-                    Cell::new(language),
-                    visibility_cell,
-                    status_cell,
-                    Cell::new(updated),
-                ]);
-            }
-
-            println!("{}", table);
-            println!(
-                "\n{} {} items",
-                filtered_items.len(),
-                if active_only { "active" } else { "total" }
-            );
         }
-    }
 
-    Ok(())
+        output.push_str(&format!(
+            "\n{table}\n\n{} {} items",
+            filtered_items.len(),
+            if active_only { "active" } else { "total" }
+        ));
+        Ok(output)
+    })
 }

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -1,86 +1,130 @@
-use crate::config::{Config, parse_server_url};
+use crate::{
+    OutputFormat,
+    config::{Config, parse_server_url},
+};
 use anyhow::Result;
 use colored::Colorize;
 use comfy_table::{Cell, Color, Table, presets::UTF8_FULL};
 use dialoguer::{Confirm, theme::ColorfulTheme};
+use serde::Serialize;
+
+/// A configured server, as `server list` and `config` report it.
+#[derive(Serialize)]
+pub struct ConfiguredServer {
+    pub name: String,
+    pub url: String,
+    /// Masked unless the caller asked for the full value.
+    pub api_key: Option<String>,
+    pub default: bool,
+}
+
+/// Shorten an API key to its recognisable head and tail.
+pub fn mask_api_key(api_key: &str) -> String {
+    if api_key.starts_with("rico_") && api_key.len() > 10 {
+        format!("{}...{}", &api_key[..8], &api_key[api_key.len() - 4..])
+    } else {
+        "***hidden***".to_string()
+    }
+}
+
+/// Collect the configured servers, sorted by name, with masked API keys.
+pub fn configured_servers(config: &Config) -> Vec<ConfiguredServer> {
+    let default_server = config.default_server();
+    let mut servers: Vec<_> = config.list_servers();
+    servers.sort_by(|a, b| a.0.cmp(b.0));
+
+    servers
+        .into_iter()
+        .map(|(name, server_config)| ConfiguredServer {
+            name: name.clone(),
+            url: server_config.url.as_str().to_string(),
+            api_key: server_config.api_key.as_deref().map(mask_api_key),
+            default: default_server == Some(name.as_str()),
+        })
+        .collect()
+}
+
+/// The outcome of a command that changed the server configuration.
+#[derive(Serialize)]
+struct ServerChange {
+    name: String,
+    default_server: Option<String>,
+}
 
 /// List all configured servers
-pub fn list(config: &Config) -> Result<()> {
-    let servers = config.list_servers();
+pub fn list(config: &Config, format: OutputFormat) -> Result<()> {
+    let servers = configured_servers(config);
 
-    if servers.is_empty() {
-        println!("{}", "No servers configured.".yellow());
-        println!(
-            "\nAdd a server with: {}",
-            "ricochet server add <name> <url>".bright_cyan()
-        );
-        return Ok(());
-    }
+    format.print(&servers, || {
+        if servers.is_empty() {
+            return Ok(format!(
+                "{}\n\nAdd a server with: {}",
+                "No servers configured.".yellow(),
+                "ricochet server add <name> <url>".bright_cyan()
+            ));
+        }
 
-    let default_server = config.default_server();
+        let mut table = Table::new();
+        table.load_style(UTF8_FULL);
+        table.set_header(vec!["Name", "URL", "API Key", "Default"]);
 
-    let mut table = Table::new();
-    table.load_style(UTF8_FULL);
-    table.set_header(vec!["Name", "URL", "API Key", "Default"]);
+        for server in &servers {
+            let name_cell = if server.default {
+                Cell::new(&server.name).fg(Color::Green)
+            } else {
+                Cell::new(&server.name)
+            };
 
-    // Collect and sort servers by name
-    let mut sorted_servers: Vec<_> = servers.into_iter().collect();
-    sorted_servers.sort_by(|a, b| a.0.cmp(b.0));
+            let api_key_status = match server.api_key {
+                Some(_) => Cell::new("configured").fg(Color::Green),
+                None => Cell::new("not set").fg(Color::Red),
+            };
 
-    for (name, server_config) in sorted_servers {
-        let is_default = default_server == Some(name.as_str());
+            let default_marker = if server.default {
+                Cell::new("*").fg(Color::Green)
+            } else {
+                Cell::new("")
+            };
 
-        let name_cell = if is_default {
-            Cell::new(name).fg(Color::Green)
-        } else {
-            Cell::new(name)
-        };
+            table.add_row(vec![
+                name_cell,
+                Cell::new(&server.url),
+                api_key_status,
+                default_marker,
+            ]);
+        }
 
-        let api_key_status = if server_config.api_key.is_some() {
-            Cell::new("configured").fg(Color::Green)
-        } else {
-            Cell::new("not set").fg(Color::Red)
-        };
+        let mut output = table.to_string();
 
-        let default_marker = if is_default {
-            Cell::new("*").fg(Color::Green)
-        } else {
-            Cell::new("")
-        };
+        // Show config file path (shell-escaped for copy-paste)
+        if let Ok(config_path) = Config::config_path() {
+            let escaped_path = config_path.display().to_string().replace(' ', "\\ ");
+            output.push_str(&format!("\n\n{} {escaped_path}", "Config:".dimmed()));
+        }
 
-        table.add_row(vec![
-            name_cell,
-            Cell::new(server_config.url.as_str()),
-            api_key_status,
-            default_marker,
-        ]);
-    }
-
-    println!("{}", table);
-
-    // Show config file path (shell-escaped for copy-paste)
-    if let Ok(config_path) = Config::config_path() {
-        let path_str = config_path.display().to_string();
-        let escaped_path = path_str.replace(' ', "\\ ");
-        println!("\n{} {}", "Config:".dimmed(), escaped_path);
-    }
-
-    Ok(())
+        Ok(output)
+    })
 }
 
 /// Add a new server
-pub fn add(config: &mut Config, name: String, url: String, default: bool) -> Result<()> {
+pub fn add(
+    config: &mut Config,
+    name: String,
+    url: String,
+    default: bool,
+    format: OutputFormat,
+) -> Result<()> {
     let parsed_url = parse_server_url(&url)?;
 
     // Check if server already exists
     if config.servers.contains_key(&name) {
         let confirmed = Confirm::with_theme(&ColorfulTheme::default())
-            .with_prompt(format!("Server '{}' already exists. Overwrite?", name))
+            .with_prompt(format!("Server '{name}' already exists. Overwrite?"))
             .default(false)
             .interact()?;
 
         if !confirmed {
-            println!("{}", "Cancelled.".yellow());
+            eprintln!("{}", "Cancelled.".yellow());
             return Ok(());
         }
     }
@@ -93,27 +137,33 @@ pub fn add(config: &mut Config, name: String, url: String, default: bool) -> Res
 
     config.save()?;
 
-    println!(
-        "{} Server '{}' added: {}",
-        "✓".green().bold(),
-        name.bright_cyan(),
-        parsed_url.as_str()
-    );
+    let change = ServerChange {
+        name,
+        default_server: config.default_server().map(str::to_string),
+    };
 
-    if config.default_server() == Some(&name) {
-        println!("  Set as default server");
-    }
+    format.print(&change, || {
+        let mut output = format!(
+            "{} Server '{}' added: {}",
+            "✓".green().bold(),
+            change.name.bright_cyan(),
+            parsed_url.as_str()
+        );
 
-    println!(
-        "\nAuthenticate with: {}",
-        format!("ricochet login --server {}", name).bright_cyan()
-    );
+        if change.default_server.as_deref() == Some(change.name.as_str()) {
+            output.push_str("\n  Set as default server");
+        }
 
-    Ok(())
+        output.push_str(&format!(
+            "\n\nAuthenticate with: {}",
+            format!("ricochet login --server {}", change.name).bright_cyan()
+        ));
+        Ok(output)
+    })
 }
 
 /// Remove a server
-pub fn remove(config: &mut Config, name: String, force: bool) -> Result<()> {
+pub fn remove(config: &mut Config, name: String, force: bool, format: OutputFormat) -> Result<()> {
     if !config.servers.contains_key(&name) {
         anyhow::bail!("Server '{}' not found", name);
     }
@@ -122,9 +172,9 @@ pub fn remove(config: &mut Config, name: String, force: bool) -> Result<()> {
 
     if !force {
         let prompt = if is_default {
-            format!("Remove default server '{}'?", name)
+            format!("Remove default server '{name}'?")
         } else {
-            format!("Remove server '{}'?", name)
+            format!("Remove server '{name}'?")
         };
 
         let confirmed = Confirm::with_theme(&ColorfulTheme::default())
@@ -133,40 +183,54 @@ pub fn remove(config: &mut Config, name: String, force: bool) -> Result<()> {
             .interact()?;
 
         if !confirmed {
-            println!("{}", "Cancelled.".yellow());
+            eprintln!("{}", "Cancelled.".yellow());
             return Ok(());
         }
     }
 
     let was_default = config.remove_server(&name)?;
     config.save()?;
+    let servers_remain = !config.servers.is_empty();
 
-    println!(
-        "{} Server '{}' removed",
-        "✓".green().bold(),
-        name.bright_cyan()
-    );
+    let change = ServerChange {
+        name,
+        default_server: config.default_server().map(str::to_string),
+    };
 
-    if was_default && !config.servers.is_empty() {
-        println!(
-            "  {}",
-            "No default server set. Use 'ricochet server set-default <name>' to set one.".yellow()
+    format.print(&change, || {
+        let mut output = format!(
+            "{} Server '{}' removed",
+            "✓".green().bold(),
+            change.name.bright_cyan()
         );
-    }
 
-    Ok(())
+        if was_default && servers_remain {
+            output.push_str(&format!(
+                "\n  {}",
+                "No default server set. Use 'ricochet server set-default <name>' to set one."
+                    .yellow()
+            ));
+        }
+
+        Ok(output)
+    })
 }
 
 /// Set the default server
-pub fn set_default(config: &mut Config, name: String) -> Result<()> {
+pub fn set_default(config: &mut Config, name: String, format: OutputFormat) -> Result<()> {
     config.set_default_server(&name)?;
     config.save()?;
 
-    println!(
-        "{} Default server set to '{}'",
-        "✓".green().bold(),
-        name.bright_cyan()
-    );
+    let change = ServerChange {
+        default_server: Some(name.clone()),
+        name,
+    };
 
-    Ok(())
+    format.print(&change, || {
+        Ok(format!(
+            "{} Default server set to '{}'",
+            "✓".green().bold(),
+            change.name.bright_cyan()
+        ))
+    })
 }

--- a/src/commands/user.rs
+++ b/src/commands/user.rs
@@ -9,33 +9,29 @@ fn format_credentials(
     credentials: &[GitCredential],
     format: OutputFormat,
 ) -> Result<String> {
-    match format {
-        OutputFormat::Json => Ok(serde_json::to_string_pretty(credentials)?),
-        OutputFormat::Yaml => Ok(serde_yaml::to_string(credentials)?),
-        OutputFormat::Table => {
-            let mut output = server_url.italic().dimmed().to_string();
+    format.render(&credentials, || {
+        let mut output = server_url.italic().dimmed().to_string();
 
-            if credentials.is_empty() {
-                output.push_str(&format!("\n{}", "No credentials found.".yellow()));
-                return Ok(output);
-            }
-
-            let mut table = Table::new();
-            table.load_style(UTF8_FULL);
-            table.set_header(vec!["ID", "Name", "Type", "User ID"]);
-            for credential in credentials {
-                table.add_row(vec![
-                    credential.id.as_str(),
-                    credential.name.as_str(),
-                    &credential.protocol.to_string(),
-                    credential.user_id.as_str(),
-                ]);
-            }
-
-            output.push_str(&format!("\n{table}\n\n{} credential(s)", credentials.len()));
-            Ok(output)
+        if credentials.is_empty() {
+            output.push_str(&format!("\n{}", "No credentials found.".yellow()));
+            return Ok(output);
         }
-    }
+
+        let mut table = Table::new();
+        table.load_style(UTF8_FULL);
+        table.set_header(vec!["ID", "Name", "Type", "User ID"]);
+        for credential in credentials {
+            table.add_row(vec![
+                credential.id.as_str(),
+                credential.name.as_str(),
+                &credential.protocol.to_string(),
+                credential.user_id.as_str(),
+            ]);
+        }
+
+        output.push_str(&format!("\n{table}\n\n{} credential(s)", credentials.len()));
+        Ok(output)
+    })
 }
 
 pub async fn list_credentials(

--- a/src/item/deployment.rs
+++ b/src/item/deployment.rs
@@ -103,37 +103,27 @@ pub async fn list_deployments(
 
     let deployments = client.list_deployments(content_ulid).await?;
 
-    match format {
-        OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(&deployments)?);
+    format.print(&deployments, || {
+        let mut output = server_config.url.as_str().italic().dimmed().to_string();
+
+        if deployments.is_empty() {
+            output.push_str(&format!("\n{}", "No deployments found.".yellow()));
+            return Ok(output);
         }
-        OutputFormat::Yaml => {
-            println!("{}", serde_yaml::to_string(&deployments)?);
+
+        let cols = resolve_fields(fields);
+
+        let mut table = Table::new();
+        table.load_style(UTF8_FULL);
+        table.set_header(cols.iter().map(|c| field_header(c)));
+
+        for d in &deployments {
+            table.add_row(cols.iter().map(|c| field_cell(c, d)));
         }
-        OutputFormat::Table => {
-            println!("{}", server_config.url.as_str().italic().dimmed());
 
-            if deployments.is_empty() {
-                println!("{}", "No deployments found.".yellow());
-                return Ok(());
-            }
-
-            let cols = resolve_fields(fields);
-
-            let mut table = Table::new();
-            table.load_style(UTF8_FULL);
-            table.set_header(cols.iter().map(|c| field_header(c)));
-
-            for d in &deployments {
-                table.add_row(cols.iter().map(|c| field_cell(c, d)));
-            }
-
-            println!("{}", table);
-            println!("\n{} deployments", deployments.len());
-        }
-    }
-
-    Ok(())
+        output.push_str(&format!("\n{table}\n\n{} deployments", deployments.len()));
+        Ok(output)
+    })
 }
 
 pub async fn get_deployment(
@@ -148,26 +138,17 @@ pub async fn get_deployment(
 
     let d = client.get_deployment(deployment_ulid).await?;
 
-    match format {
-        OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(&d)?);
+    format.print(&d, || {
+        let mut table = Table::new();
+        table.load_style(UTF8_FULL);
+
+        for col in ALL_FIELDS {
+            table.add_row(vec![Cell::new(field_header(col)), field_cell(col, &d)]);
         }
-        OutputFormat::Yaml => {
-            println!("{}", serde_yaml::to_string(&d)?);
-        }
-        OutputFormat::Table => {
-            println!("{}", server_config.url.as_str().italic().dimmed());
 
-            let mut table = Table::new();
-            table.load_style(UTF8_FULL);
-
-            for col in ALL_FIELDS {
-                table.add_row(vec![Cell::new(field_header(col)), field_cell(col, &d)]);
-            }
-
-            println!("{}", table);
-        }
-    }
-
-    Ok(())
+        Ok(format!(
+            "{}\n{table}",
+            server_config.url.as_str().italic().dimmed()
+        ))
+    })
 }

--- a/src/item/env_vars.rs
+++ b/src/item/env_vars.rs
@@ -15,34 +15,27 @@ fn env_dir(path: Option<&Path>) -> PathBuf {
 }
 
 fn print_names(server_url: &str, names: &[String], format: OutputFormat) -> Result<()> {
-    match format {
-        OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(&names)?);
+    format.print(&names, || {
+        let mut output = server_url.italic().dimmed().to_string();
+
+        if names.is_empty() {
+            output.push_str(&format!("\n{}", "No environment variables found.".yellow()));
+            return Ok(output);
         }
-        OutputFormat::Yaml => {
-            println!("{}", serde_yaml::to_string(&names)?);
+
+        let mut table = Table::new();
+        table.load_style(UTF8_FULL);
+        table.set_header(vec!["Name"]);
+        for name in names {
+            table.add_row(vec![name]);
         }
-        OutputFormat::Table => {
-            println!("{}", server_url.italic().dimmed());
 
-            if names.is_empty() {
-                println!("{}", "No environment variables found.".yellow());
-                return Ok(());
-            }
-
-            let mut table = Table::new();
-            table.load_style(UTF8_FULL);
-            table.set_header(vec!["Name"]);
-            for name in names {
-                table.add_row(vec![name]);
-            }
-
-            println!("{}", table);
-            println!("\n{} environment variable(s)", names.len());
-        }
-    }
-
-    Ok(())
+        output.push_str(&format!(
+            "\n{table}\n\n{} environment variable(s)",
+            names.len()
+        ));
+        Ok(output)
+    })
 }
 
 pub async fn get_env_vars(

--- a/src/item/invoke.rs
+++ b/src/item/invoke.rs
@@ -18,50 +18,35 @@ pub async fn invoke(
 
     match client.invoke(id, None).await {
         Ok(result) => {
-            eprintln!("{} Task invoked successfully!\n", "✓".green().bold());
+            eprintln!("{} Task invoked successfully!", "✓".green().bold());
 
-            match format {
-                OutputFormat::Json => {
-                    println!("{}", serde_json::to_string_pretty(&result)?);
+            format.print(&result, || {
+                let mut table = Table::new();
+                table.load_style(UTF8_FULL);
+
+                if let Some(invocation_id) = result.get("invocation_id").and_then(|v| v.as_str()) {
+                    table.add_row(vec![Cell::new("Invocation ID"), Cell::new(invocation_id)]);
                 }
-                OutputFormat::Yaml => {
-                    println!("{}", serde_yaml::to_string(&result)?);
+
+                if let Some(content_id) = result.get("content_id").and_then(|v| v.as_str()) {
+                    table.add_row(vec![Cell::new("Content ID"), Cell::new(content_id)]);
                 }
-                OutputFormat::Table => {
-                    // Display server URL above the table
-                    println!("{}", server_config.url.as_str().italic().dimmed());
 
-                    let mut table = Table::new();
-                    table.load_style(UTF8_FULL);
-
-                    if let Some(invocation_id) =
-                        result.get("invocation_id").and_then(|v| v.as_str())
-                    {
-                        table.add_row(vec![Cell::new("Invocation ID"), Cell::new(invocation_id)]);
-                    }
-
-                    if let Some(content_id) = result.get("content_id").and_then(|v| v.as_str()) {
-                        table.add_row(vec![Cell::new("Content ID"), Cell::new(content_id)]);
-                    }
-
-                    // Add status with color coding
-                    if let Some(status) = result.get("status").and_then(|v| v.as_str()) {
-                        let status_cell = match status {
-                            "running" | "success" | "completed" => {
-                                Cell::new(status).fg(Color::Green)
-                            }
-                            "failed" | "error" => Cell::new(status).fg(Color::Red),
-                            "pending" | "queued" => Cell::new(status).fg(Color::Yellow),
-                            _ => Cell::new(status),
-                        };
-                        table.add_row(vec![Cell::new("Status"), status_cell]);
-                    }
-
-                    println!("{}", table);
+                if let Some(status) = result.get("status").and_then(|v| v.as_str()) {
+                    let status_cell = match status {
+                        "running" | "success" | "completed" => Cell::new(status).fg(Color::Green),
+                        "failed" | "error" => Cell::new(status).fg(Color::Red),
+                        "pending" | "queued" => Cell::new(status).fg(Color::Yellow),
+                        _ => Cell::new(status),
+                    };
+                    table.add_row(vec![Cell::new("Status"), status_cell]);
                 }
-            }
 
-            Ok(())
+                Ok(format!(
+                    "{}\n{table}",
+                    server_config.url.as_str().italic().dimmed()
+                ))
+            })
         }
         Err(e) => {
             anyhow::bail!("Failed to invoke task: {e}")

--- a/src/item/schedule.rs
+++ b/src/item/schedule.rs
@@ -27,25 +27,16 @@ pub async fn schedule_task(
         .await
         .context("sending API request")?;
 
-    match format {
-        OutputFormat::Table => {
-            println!("{} Schedule updated successfully", "✓".green().bold());
-            println!();
-            println!("  {:<12} {}", "Schedule:".dimmed(), schedule);
-            println!("  {:<12} {}", "Runs:".dimmed(), cron.describe());
-            println!(
-                "  {:<12} {} UTC",
-                "Next run:".dimmed(),
-                next.format("%Y-%m-%d %H:%M:%S")
-            );
-        }
-        OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(&res)?);
-        }
-        OutputFormat::Yaml => {
-            println!("{}", serde_yaml::to_string(&res)?);
-        }
-    }
-
-    Ok(())
+    format.print(&res, || {
+        Ok(format!(
+            "{} Schedule updated successfully\n\n  {:<12} {}\n  {:<12} {}\n  {:<12} {} UTC",
+            "✓".green().bold(),
+            "Schedule:".dimmed(),
+            schedule,
+            "Runs:".dimmed(),
+            cron.describe(),
+            "Next run:".dimmed(),
+            next.format("%Y-%m-%d %H:%M:%S")
+        ))
+    })
 }

--- a/src/item/settings.rs
+++ b/src/item/settings.rs
@@ -351,24 +351,19 @@ pub async fn preview(
 
     let (changes, patch) = diff_against_remote(&client, &id, &local).await?;
 
-    match format {
-        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&patch)?),
-        OutputFormat::Yaml => println!("{}", serde_yaml::to_string(&patch)?),
-        OutputFormat::Table => {
-            if changes.is_empty() {
-                println!("{} Settings already up to date", "✓".green().bold());
-            } else {
-                println!("{}", format_changes(&id, &local.content.name, &changes));
-                println!();
-                println!(
-                    "Run {} to apply these changes.",
-                    "settings update".bright_cyan()
-                );
-            }
+    format.print(&patch, || {
+        if changes.is_empty() {
+            return Ok(format!(
+                "{} Settings already up to date",
+                "✓".green().bold()
+            ));
         }
-    }
-
-    Ok(())
+        Ok(format!(
+            "{}\n\nRun {} to apply these changes.",
+            format_changes(&id, &local.content.name, &changes),
+            "settings update".bright_cyan()
+        ))
+    })
 }
 
 /// Apply the local `_ricochet.toml` settings to the deployed item.
@@ -387,8 +382,12 @@ pub async fn update(
     let (changes, patch) = diff_against_remote(&client, &id, &local).await?;
 
     if changes.is_empty() {
-        eprintln!("{} Settings already up to date", "✓".green().bold());
-        return Ok(());
+        return format.print(&patch, || {
+            Ok(format!(
+                "{} Settings already up to date",
+                "✓".green().bold()
+            ))
+        });
     }
 
     eprintln!("{}", format_changes(&id, &local.content.name, &changes));
@@ -404,19 +403,13 @@ pub async fn update(
         .await
         .context("sending settings update")?;
 
-    match format {
-        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&patch)?),
-        OutputFormat::Yaml => println!("{}", serde_yaml::to_string(&patch)?),
-        OutputFormat::Table => {
-            println!(
-                "{} Settings updated for {}",
-                "✓".green().bold(),
-                id.bright_cyan()
-            )
-        }
-    }
-
-    Ok(())
+    format.print(&patch, || {
+        Ok(format!(
+            "{} Settings updated for {}",
+            "✓".green().bold(),
+            id.bright_cyan()
+        ))
+    })
 }
 
 #[cfg(test)]

--- a/src/item/toml.rs
+++ b/src/item/toml.rs
@@ -1,17 +1,31 @@
-use crate::{client::RicochetClient, config::Config, item::resolve_id};
+use crate::{OutputFormat, client::RicochetClient, config::Config, item::resolve_id};
+use anyhow::Result;
+use serde::Serialize;
 use std::path::PathBuf;
+
+/// The remote `_ricochet.toml` of a content item.
+#[derive(Serialize)]
+struct RemoteToml {
+    content_id: String,
+    toml: String,
+}
 
 pub async fn get_toml(
     config: &Config,
+    server_ref: Option<&str>,
     id: Option<String>,
     path: Option<PathBuf>,
-) -> anyhow::Result<()> {
-    let server_config = config.resolve_server(None)?;
+    format: OutputFormat,
+) -> Result<()> {
+    let server_config = config.resolve_server(server_ref)?;
     let client = RicochetClient::new(&server_config)?;
     client.preflight_key_check().await?;
 
     let id = resolve_id(id.as_deref(), path.as_deref())?;
+    let remote = RemoteToml {
+        toml: client.get_ricochet_toml(&id).await?,
+        content_id: id,
+    };
 
-    println!("{}", client.get_ricochet_toml(&id).await?);
-    Ok(())
+    format.print(&remote, || Ok(remote.toml.clone()))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,13 +5,9 @@ pub mod config;
 pub mod crypto;
 pub mod env_vars;
 pub mod item;
+pub mod output;
 pub mod task;
 pub mod update;
 pub mod utils;
 
-#[derive(clap::ValueEnum, Clone, Debug, Copy)]
-pub enum OutputFormat {
-    Table,
-    Json,
-    Yaml,
-}
+pub use output::OutputFormat;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ struct Cli {
     )]
     server: Option<String>,
 
-    /// Output format
+    /// Output format. `json` and `yaml` write the payload to stdout and everything else to stderr
     #[arg(
         global = true,
         short = 'F',
@@ -451,10 +451,10 @@ async fn main() -> Result<()> {
     // Execute command
     match cli.command {
         Some(Commands::Login { api_key }) => {
-            commands::auth::login(&mut config, cli.server.as_deref(), api_key).await?;
+            commands::auth::login(&mut config, cli.server.as_deref(), api_key, cli.format).await?;
         }
         Some(Commands::Logout) => {
-            commands::auth::logout(&mut config, cli.server.as_deref())?;
+            commands::auth::logout(&mut config, cli.server.as_deref(), cli.format)?;
         }
         Some(Commands::Deploy {
             path,
@@ -476,6 +476,7 @@ async fn main() -> Result<()> {
                     repo_path,
                     config_path,
                     credential,
+                    cli.format,
                 )
                 .await?;
             } else {
@@ -486,13 +487,15 @@ async fn main() -> Result<()> {
                     name,
                     description,
                     env,
+                    cli.format,
                     cli.debug,
                 )
                 .await?;
             }
         }
         Some(Commands::Delete { id, force }) => {
-            commands::delete::delete(&config, cli.server.as_deref(), &id, force).await?;
+            commands::delete::delete(&config, cli.server.as_deref(), &id, force, cli.format)
+                .await?;
         }
         Some(Commands::Invoke { id }) => {
             eprintln!(
@@ -502,7 +505,7 @@ async fn main() -> Result<()> {
             item::invoke::invoke(&config, cli.server.as_deref(), &id, cli.format).await?;
         }
         Some(Commands::Config { show_all }) => {
-            commands::config::show(&config, show_all)?;
+            commands::config::show(&config, show_all, cli.format)?;
         }
         Some(Commands::Init {
             path,
@@ -514,7 +517,7 @@ async fn main() -> Result<()> {
 
         Some(Commands::App { command }) => match command {
             ItemCommands::Toml { id, path } => {
-                item::toml::get_toml(&config, id, path).await?;
+                item::toml::get_toml(&config, cli.server.as_deref(), id, path, cli.format).await?;
             }
             ItemCommands::List {
                 content_type,
@@ -550,6 +553,7 @@ async fn main() -> Result<()> {
                     id.as_deref(),
                     pid.as_deref(),
                     path.as_deref(),
+                    cli.format,
                 )
                 .await?;
             }
@@ -676,7 +680,7 @@ async fn main() -> Result<()> {
                 .await?;
             }
             TaskCommands::Toml { id, path } => {
-                item::toml::get_toml(&config, id, path).await?;
+                item::toml::get_toml(&config, cli.server.as_deref(), id, path, cli.format).await?;
             }
             TaskCommands::Invoke { id } => {
                 item::invoke::invoke(&config, cli.server.as_deref(), &id, cli.format).await?;
@@ -797,16 +801,16 @@ async fn main() -> Result<()> {
         },
         Some(Commands::Server { command }) => match command {
             ServerCommands::List => {
-                commands::server::list(&config)?;
+                commands::server::list(&config, cli.format)?;
             }
             ServerCommands::Add { name, url, default } => {
-                commands::server::add(&mut config, name, url, default)?;
+                commands::server::add(&mut config, name, url, default, cli.format)?;
             }
             ServerCommands::Remove { name, force } => {
-                commands::server::remove(&mut config, name, force)?;
+                commands::server::remove(&mut config, name, force, cli.format)?;
             }
             ServerCommands::SetDefault { name } => {
-                commands::server::set_default(&mut config, name)?;
+                commands::server::set_default(&mut config, name, cli.format)?;
             }
         },
         Some(Commands::User { command }) => match command {

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,72 @@
+//! Output rules shared by every command.
+//!
+//! `-F json` and `-F yaml` reserve stdout for the serialised payload, so status
+//! lines, hints, spinners and links belong on stderr.
+
+use anyhow::Result;
+use serde::Serialize;
+
+#[derive(clap::ValueEnum, Clone, Debug, Copy, PartialEq, Eq)]
+pub enum OutputFormat {
+    Table,
+    Json,
+    Yaml,
+}
+
+impl OutputFormat {
+    /// Render `payload` for a machine reader, or call `table` for a person.
+    pub fn render<T: Serialize>(
+        self,
+        payload: &T,
+        table: impl FnOnce() -> Result<String>,
+    ) -> Result<String> {
+        match self {
+            Self::Json => Ok(serde_json::to_string_pretty(payload)?),
+            Self::Yaml => Ok(serde_yaml::to_string(payload)?.trim_end().to_string()),
+            Self::Table => table(),
+        }
+    }
+
+    /// Write the rendered payload to stdout, the only stream a caller parses.
+    pub fn print<T: Serialize>(
+        self,
+        payload: &T,
+        table: impl FnOnce() -> Result<String>,
+    ) -> Result<()> {
+        println!("{}", self.render(payload, table)?);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn json_carries_the_payload_alone() -> Result<()> {
+        let rendered =
+            OutputFormat::Json.render(&json!({"id": "01J"}), || Ok("human text".to_string()))?;
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&rendered)?["id"],
+            "01J"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn yaml_carries_the_payload_alone() -> Result<()> {
+        let rendered =
+            OutputFormat::Yaml.render(&json!({"id": "01J"}), || Ok("human text".to_string()))?;
+        assert_eq!(rendered, "id: 01J");
+        Ok(())
+    }
+
+    #[test]
+    fn table_defers_to_the_human_rendering() -> Result<()> {
+        let rendered =
+            OutputFormat::Table.render(&json!({"id": "01J"}), || Ok("human text".to_string()))?;
+        assert_eq!(rendered, "human text");
+        Ok(())
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -111,19 +111,19 @@ pub fn create_bundle(
     let files_to_bundle = prepare_bundle(dir, include, exclude)?;
 
     if debug {
-        println!("\nDebug: Files being bundled:");
+        eprintln!("\nDebug: Files being bundled:");
         for path in &files_to_bundle {
             if path.is_file()
                 && let Ok(metadata) = std::fs::metadata(path)
             {
                 let size = metadata.len();
                 let relative_path = path.strip_prefix(dir).unwrap_or(path);
-                println!("  {} - {}", relative_path.display(), format_size(size));
+                eprintln!("  {} - {}", relative_path.display(), format_size(size));
             }
         }
         for (source, name) in extra_root_files {
             if let Ok(metadata) = std::fs::metadata(source) {
-                println!(
+                eprintln!(
                     "  {} (from {}) - {}",
                     name,
                     source.display(),
@@ -131,7 +131,7 @@ pub fn create_bundle(
                 );
             }
         }
-        println!();
+        eprintln!();
     }
 
     // Add files to tar (directories will be created automatically)

--- a/tests/content_toml.rs
+++ b/tests/content_toml.rs
@@ -1,5 +1,5 @@
 use mockito::Server;
-use ricochet_cli::{config::Config, item::toml::get_toml};
+use ricochet_cli::{OutputFormat, config::Config, item::toml::get_toml};
 use std::{env, fs};
 use tempfile::TempDir;
 
@@ -85,8 +85,10 @@ async fn test_get_toml_with_provided_id() {
     // Test with provided ID
     let result = get_toml(
         &config,
+        None,
         Some("01KE52BY41EQ7NE89K7Z5MMZ84".to_string()),
         None,
+        OutputFormat::Table,
     )
     .await;
 
@@ -116,7 +118,7 @@ async fn test_get_toml_with_default_path() {
     env::set_current_dir(temp_dir.path()).unwrap();
 
     // Test without ID or path (should read from ./_ricochet.toml)
-    let result = get_toml(&config, None, None).await;
+    let result = get_toml(&config, None, None, None, OutputFormat::Table).await;
 
     // Restore original directory
     env::set_current_dir(original_dir).unwrap();
@@ -148,7 +150,7 @@ async fn test_get_toml_with_specified_path() {
     fs::write(&toml_path, LOCAL_TOML_CONTENT).unwrap();
 
     // Test with specified path
-    let result = get_toml(&config, None, Some(toml_path)).await;
+    let result = get_toml(&config, None, None, Some(toml_path), OutputFormat::Table).await;
 
     assert!(
         result.is_ok(),
@@ -174,7 +176,7 @@ async fn test_get_toml_missing_id_and_file() {
     env::set_current_dir(temp_dir.path()).unwrap();
 
     // Test without ID or path and no _ricochet.toml should fail
-    let result = get_toml(&config, None, None).await;
+    let result = get_toml(&config, None, None, None, OutputFormat::Table).await;
 
     env::set_current_dir(original_dir).unwrap();
 
@@ -215,7 +217,7 @@ packages = "renv.lock"
     env::set_current_dir(temp_dir.path()).unwrap();
 
     // Test should fail because _ricochet.toml has no id
-    let result = get_toml(&config, None, None).await;
+    let result = get_toml(&config, None, None, None, OutputFormat::Table).await;
 
     env::set_current_dir(original_dir).unwrap();
 

--- a/tests/delete_test.rs
+++ b/tests/delete_test.rs
@@ -1,4 +1,5 @@
 use mockito::Server;
+use ricochet_cli::OutputFormat;
 use serde_json::json;
 use url::Url;
 
@@ -26,7 +27,14 @@ mod delete_tests {
         );
 
         // Test delete with force flag (no confirmation)
-        let result = ricochet_cli::commands::delete::delete(&config, None, content_id, true).await;
+        let result = ricochet_cli::commands::delete::delete(
+            &config,
+            None,
+            content_id,
+            true,
+            OutputFormat::Table,
+        )
+        .await;
 
         assert!(result.is_ok());
     }
@@ -52,7 +60,14 @@ mod delete_tests {
         );
 
         // Test delete with non-existent content
-        let result = ricochet_cli::commands::delete::delete(&config, None, content_id, true).await;
+        let result = ricochet_cli::commands::delete::delete(
+            &config,
+            None,
+            content_id,
+            true,
+            OutputFormat::Table,
+        )
+        .await;
 
         assert!(result.is_err());
         let error_msg = result.unwrap_err().to_string();
@@ -80,7 +95,14 @@ mod delete_tests {
         );
 
         // Test delete with invalid API key
-        let result = ricochet_cli::commands::delete::delete(&config, None, content_id, true).await;
+        let result = ricochet_cli::commands::delete::delete(
+            &config,
+            None,
+            content_id,
+            true,
+            OutputFormat::Table,
+        )
+        .await;
 
         assert!(result.is_err());
     }
@@ -106,7 +128,14 @@ mod delete_tests {
         );
 
         // Test delete with server error
-        let result = ricochet_cli::commands::delete::delete(&config, None, content_id, true).await;
+        let result = ricochet_cli::commands::delete::delete(
+            &config,
+            None,
+            content_id,
+            true,
+            OutputFormat::Table,
+        )
+        .await;
 
         assert!(result.is_err());
         let error_msg = result.unwrap_err().to_string();
@@ -132,7 +161,14 @@ mod delete_tests {
             Some("test_api_key".to_string()),
         );
 
-        let result = ricochet_cli::commands::delete::delete(&config, None, content_id, true).await;
+        let result = ricochet_cli::commands::delete::delete(
+            &config,
+            None,
+            content_id,
+            true,
+            OutputFormat::Table,
+        )
+        .await;
 
         assert!(result.is_ok());
     }
@@ -169,13 +205,25 @@ mod delete_tests {
         );
 
         // Delete first item
-        let result1 =
-            ricochet_cli::commands::delete::delete(&config, None, content_id1, true).await;
+        let result1 = ricochet_cli::commands::delete::delete(
+            &config,
+            None,
+            content_id1,
+            true,
+            OutputFormat::Table,
+        )
+        .await;
         assert!(result1.is_ok());
 
         // Delete second item
-        let result2 =
-            ricochet_cli::commands::delete::delete(&config, None, content_id2, true).await;
+        let result2 = ricochet_cli::commands::delete::delete(
+            &config,
+            None,
+            content_id2,
+            true,
+            OutputFormat::Table,
+        )
+        .await;
         assert!(result2.is_ok());
     }
 }

--- a/tests/deploy_git_test.rs
+++ b/tests/deploy_git_test.rs
@@ -1,4 +1,5 @@
 use mockito::{Matcher, Server};
+use ricochet_cli::OutputFormat;
 use serde_json::json;
 use url::Url;
 
@@ -40,6 +41,7 @@ async fn test_deploy_git_success_minimal() {
         None,
         None,
         None,
+        OutputFormat::Table,
     )
     .await;
 
@@ -78,6 +80,7 @@ async fn test_deploy_git_success_with_all_fields() {
         Some("apps/dashboard".to_string()),
         Some(toml_path),
         Some("cred_123".to_string()),
+        OutputFormat::Table,
     )
     .await;
 
@@ -106,6 +109,7 @@ async fn test_deploy_git_bad_request() {
         None,
         None,
         None,
+        OutputFormat::Table,
     )
     .await;
 
@@ -134,6 +138,7 @@ async fn test_deploy_git_forbidden() {
         None,
         None,
         None,
+        OutputFormat::Table,
     )
     .await;
 

--- a/tests/deploy_test.rs
+++ b/tests/deploy_test.rs
@@ -1,4 +1,5 @@
 use mockito::{Matcher, Server};
+use ricochet_cli::OutputFormat;
 use ricochet_cli::config::{Config, ServerConfig};
 use serde_json::json;
 use std::collections::HashMap;
@@ -154,6 +155,7 @@ shinyApp(ui = ui, server = server)"#,
             None,
             None,
             Vec::new(),
+            OutputFormat::Table,
             false,
         )
         .await;
@@ -212,6 +214,7 @@ shinyApp(ui = ui, server = server)"#,
             None,
             None,
             Vec::new(),
+            OutputFormat::Table,
             false,
         )
         .await;
@@ -249,6 +252,7 @@ shinyApp(ui = ui, server = server)"#,
             None,
             None,
             Vec::new(),
+            OutputFormat::Table,
             false,
         )
         .await;
@@ -295,6 +299,7 @@ key = "value"
             None,
             None,
             Vec::new(),
+            OutputFormat::Table,
             false,
         )
         .await;
@@ -335,6 +340,7 @@ key = "value"
             None,
             None,
             Vec::new(),
+            OutputFormat::Table,
             false,
         )
         .await;
@@ -393,6 +399,7 @@ key = "value"
             None,
             None,
             Vec::new(),
+            OutputFormat::Table,
             false,
         )
         .await;
@@ -453,6 +460,7 @@ key = "value"
             None,
             None,
             Vec::new(),
+            OutputFormat::Table,
             false,
         )
         .await;
@@ -503,6 +511,7 @@ key = "value"
             None,
             None,
             Vec::new(),
+            OutputFormat::Table,
             false,
         )
         .await;
@@ -558,6 +567,7 @@ key = "value"
             None,
             None,
             Vec::new(),
+            OutputFormat::Table,
             false,
         )
         .await;
@@ -609,6 +619,7 @@ key = "value"
             None,
             None,
             Vec::new(),
+            OutputFormat::Table,
             false,
         )
         .await;
@@ -662,6 +673,7 @@ key = "value"
             None,
             None,
             Vec::new(),
+            OutputFormat::Table,
             false,
         )
         .await;
@@ -729,6 +741,7 @@ packages = "uv.lock"
             None,
             None,
             Vec::new(),
+            OutputFormat::Table,
             false,
         )
         .await;
@@ -776,6 +789,7 @@ packages = "renv.lock"
             None,
             None,
             Vec::new(),
+            OutputFormat::Table,
             false,
         )
         .await;
@@ -809,6 +823,7 @@ packages = "renv.lock"
             None,
             None,
             Vec::new(),
+            OutputFormat::Table,
             false,
         )
         .await;
@@ -843,6 +858,7 @@ packages = "renv.lock"
             None,
             None,
             Vec::new(),
+            OutputFormat::Table,
             false,
         )
         .await;
@@ -891,6 +907,7 @@ packages = "renv.lock"
             None,
             None,
             Vec::new(),
+            OutputFormat::Table,
             false,
         )
         .await;
@@ -949,6 +966,7 @@ packages = "renv.lock"
             None,
             None,
             Vec::new(),
+            OutputFormat::Table,
             false,
         )
         .await;
@@ -994,6 +1012,7 @@ packages = "renv.lock"
             None,
             None,
             Vec::new(),
+            OutputFormat::Table,
             false,
         )
         .await;
@@ -1020,6 +1039,7 @@ packages = "renv.lock"
             None,
             None,
             Vec::new(),
+            OutputFormat::Table,
             false,
         )
         .await;
@@ -1059,6 +1079,7 @@ packages = "renv.lock"
             None,
             None,
             vec!["SECRET=shh".to_string()],
+            OutputFormat::Table,
             false,
         )
         .await;
@@ -1100,6 +1121,7 @@ packages = "renv.lock"
             None,
             None,
             Vec::new(),
+            OutputFormat::Table,
             false,
         )
         .await;
@@ -1138,6 +1160,7 @@ packages = "renv.lock"
             None,
             None,
             vec!["SECRET=shh".to_string()],
+            OutputFormat::Table,
             false,
         )
         .await;

--- a/tests/instances_test.rs
+++ b/tests/instances_test.rs
@@ -1,4 +1,5 @@
 use mockito::Server;
+use ricochet_cli::OutputFormat;
 use serde_json::json;
 use url::Url;
 
@@ -218,6 +219,7 @@ mod instances_tests {
             Some(content_id),
             None,
             None,
+            OutputFormat::Table,
         )
         .await;
 
@@ -258,6 +260,7 @@ mod instances_tests {
             Some(content_id),
             None,
             None,
+            OutputFormat::Table,
         )
         .await;
 

--- a/tests/json_output_test.rs
+++ b/tests/json_output_test.rs
@@ -1,0 +1,585 @@
+//! `-F json` and `-F yaml` reserve stdout for the payload.
+//!
+//! Every test drives the real binary so it catches any status line, hint or
+//! link that a command writes to stdout instead of stderr.
+
+use mockito::{Matcher, Server, ServerGuard};
+use serde_json::json;
+use std::path::Path;
+use tempfile::TempDir;
+
+const CONTENT_ID: &str = "01K66JV2Q123456789ABCDEF";
+const DEPLOYMENT_ID: &str = "01KQZPF4Y5SRHES967VZEYY765";
+const INSTANCE_ID: &str = "01KQZMZXE17RV7TCNF3GGG24P4";
+
+/// Test-only RSA public key, served so the env-var commands can encrypt.
+const TEST_PUB_PEM: &str = "-----BEGIN RSA PUBLIC KEY-----
+MIIBCgKCAQEAr1XuDE4bFt7TnYqAtiRQ9RvC2sG3s8N8zUsCvhM+mZD7mGTN47bk
+vYxKvp5ShVnM/6XZeCfRQA2TKXnf6dWsRgcZcBMufKHfN9VLNxawLMKHddceHlLA
+rFTwsPE9rU9p5p5uA6zhUnZk/skzWumqZw9WK7Lztbh6fhX9UMYXvaBzCFF1nfTM
+kGl7YkRcwfL4p+1oa7uGFYaRxvBKv6q9/hm7W9Em7H0g4+icc85wkvlzJrghKakp
+5wDkaY8XmSGSiOZr0U8/fPBC4SASPuT5Hy17zZwu7SEYW31JYnRvFoo8bF8N3QxT
+WigXLNxbQJjhAq7Y6mU8h7yF2zWMbFGMqwIDAQAB
+-----END RSA PUBLIC KEY-----
+";
+
+const REMOTE_TOML: &str = r#"[content]
+id = "01K66JV2Q123456789ABCDEF"
+name = "remote-app"
+entrypoint = "app.R"
+access_type = "external"
+content_type = "shiny"
+
+[language]
+name = "r"
+packages = "renv.lock"
+"#;
+
+const LOCAL_TOML: &str = r#"[content]
+id = "01K66JV2Q123456789ABCDEF"
+name = "local-app"
+entrypoint = "app.R"
+access_type = "external"
+content_type = "shiny"
+
+[language]
+name = "r"
+packages = "renv.lock"
+"#;
+
+/// Register every endpoint the exercised commands touch.
+fn mock_api(server: &mut Server) {
+    server
+        .mock("GET", "/api/v0/check_key")
+        .with_status(200)
+        .create();
+
+    server
+        .mock("GET", "/api/v0/public-key")
+        .with_status(200)
+        .with_header("content-type", "application/x-pem-file")
+        .with_body(TEST_PUB_PEM)
+        .create();
+
+    server
+        .mock("GET", "/api/v0/user/items")
+        .with_status(200)
+        .with_body(
+            json!([
+                {
+                    "id": CONTENT_ID,
+                    "name": "Metadata Dashboard",
+                    "content_type": "shiny",
+                    "language": "R",
+                    "visibility": "private",
+                    "status": "deployed",
+                    "updated_at": "2024-01-15T10:30:00Z"
+                },
+                {
+                    "id": "01K66JV2Q987654321FEDCBA",
+                    "name": "Nightly Report",
+                    "content_type": "quarto-r",
+                    "language": "R",
+                    "visibility": "private",
+                    "status": "success",
+                    "updated_at": "2024-01-16T14:20:00Z"
+                }
+            ])
+            .to_string(),
+        )
+        .create();
+
+    server
+        .mock("GET", "/api/v0/user/credentials")
+        .match_query(Matcher::Any)
+        .with_status(200)
+        .with_body(
+            json!([{
+                "id": "credential-id",
+                "user_id": "user-id",
+                "name": "deploy-key",
+                "type": "ssh"
+            }])
+            .to_string(),
+        )
+        .create();
+
+    server
+        .mock("GET", format!("/api/v0/content/{CONTENT_ID}/toml").as_str())
+        .with_status(200)
+        .with_header("content-type", "application/toml")
+        .with_body(REMOTE_TOML)
+        .create();
+
+    server
+        .mock(
+            "GET",
+            format!("/api/v0/content/{CONTENT_ID}/instances").as_str(),
+        )
+        .with_status(200)
+        .with_body(
+            json!([{
+                "instance_id": INSTANCE_ID,
+                "connections": 2,
+                "created_at": "2024-01-15T10:30:00Z",
+                "last_connection": 0
+            }])
+            .to_string(),
+        )
+        .create();
+
+    server
+        .mock(
+            "POST",
+            format!("/api/v0/content/{CONTENT_ID}/instances/{INSTANCE_ID}/stop").as_str(),
+        )
+        .with_status(200)
+        .create();
+
+    server
+        .mock(
+            "GET",
+            format!("/api/v0/content/{CONTENT_ID}/deployments").as_str(),
+        )
+        .with_status(200)
+        .with_body(json!([deployment()]).to_string())
+        .create();
+
+    server
+        .mock(
+            "GET",
+            format!("/api/v0/content/deployments/{DEPLOYMENT_ID}").as_str(),
+        )
+        .with_status(200)
+        .with_body(deployment().to_string())
+        .create();
+
+    for method in ["GET", "PATCH", "PUT"] {
+        server
+            .mock(
+                method,
+                format!("/api/v0/content/{CONTENT_ID}/env-vars").as_str(),
+            )
+            .with_status(200)
+            .with_body(json!(["DATABASE_URL"]).to_string())
+            .create();
+    }
+
+    server
+        .mock(
+            "DELETE",
+            format!("/api/v0/content/{CONTENT_ID}/env-vars/DATABASE_URL").as_str(),
+        )
+        .with_status(200)
+        .with_body(json!([]).to_string())
+        .create();
+
+    server
+        .mock(
+            "POST",
+            format!("/api/v0/content/{CONTENT_ID}/invoke").as_str(),
+        )
+        .with_status(200)
+        .with_body(
+            json!({
+                "invocation_id": "01KQZPF4Y5SRHES967VZEYY765",
+                "content_id": CONTENT_ID,
+                "status": "pending"
+            })
+            .to_string(),
+        )
+        .create();
+
+    server
+        .mock(
+            "PATCH",
+            format!("/api/v0/content/{CONTENT_ID}/schedule").as_str(),
+        )
+        .with_status(200)
+        .with_body(json!({"content_id": CONTENT_ID, "schedule": "0 9 * * 1-5"}).to_string())
+        .create();
+
+    server
+        .mock(
+            "PATCH",
+            format!("/api/v0/content/{CONTENT_ID}/settings").as_str(),
+        )
+        .with_status(200)
+        .create();
+
+    server
+        .mock("DELETE", format!("/api/v0/content/{CONTENT_ID}").as_str())
+        .with_status(200)
+        .create();
+
+    server
+        .mock("POST", "/api/v0/content/upload")
+        .match_body(Matcher::Any)
+        .with_status(200)
+        .with_body(
+            json!({"id": CONTENT_ID, "deployment_id": DEPLOYMENT_ID, "status": "deployed"})
+                .to_string(),
+        )
+        .create();
+
+    server
+        .mock("POST", "/api/v0/deploy/git")
+        .match_body(Matcher::Any)
+        .with_status(200)
+        .with_body(json!({"id": CONTENT_ID}).to_string())
+        .create();
+}
+
+fn deployment() -> serde_json::Value {
+    json!({
+        "id": DEPLOYMENT_ID,
+        "content_id": CONTENT_ID,
+        "deployed_at": 1778106471,
+        "status": "success",
+        "deployed_by": "344509059241640593",
+        "ip_address": "127.0.0.1",
+        "requested_ver": "4.5.1",
+        "matched_ver": "4.5.2",
+        "git_hash": null
+    })
+}
+
+/// A mock server plus the throwaway home directory the CLI stores its config in.
+struct Cli {
+    /// Held so the mock server outlives the commands under test.
+    _server: ServerGuard,
+    home: TempDir,
+}
+
+impl Cli {
+    async fn new() -> Self {
+        let mut server = Server::new_async().await;
+        mock_api(&mut server);
+
+        // The CLI reads its configuration from `$HOME/.config/ricochet`.
+        let home = TempDir::new().expect("creating a temporary home");
+        let config_dir = home.path().join(".config").join("ricochet");
+        std::fs::create_dir_all(&config_dir).expect("creating the config directory");
+        std::fs::write(
+            config_dir.join("config.toml"),
+            format!(
+                "default_server = \"test\"\ndefault_format = \"table\"\n\n[servers.test]\nurl = \"{}\"\napi_key = \"test_api_key\"\n",
+                server.url()
+            ),
+        )
+        .expect("writing the test config");
+
+        Self {
+            _server: server,
+            home,
+        }
+    }
+
+    async fn run(&self, args: &[&str]) -> std::process::Output {
+        tokio::process::Command::new(env!("CARGO_BIN_EXE_ricochet"))
+            .args(args)
+            .env("HOME", self.home.path())
+            .env_remove("RICOCHET_SERVER")
+            .env_remove("RICOCHET_API_KEY")
+            .env("RICOCHET_NO_UPDATE_CHECK", "1")
+            .env("NO_COLOR", "1")
+            .output()
+            .await
+            .expect("running the ricochet binary")
+    }
+
+    /// Run with `-F json` and return the parsed stdout.
+    async fn json(&self, args: &[&str]) -> serde_json::Value {
+        let mut with_format = args.to_vec();
+        with_format.extend(["-F", "json"]);
+        let output = self.run(&with_format).await;
+        let stdout = String::from_utf8(output.stdout).expect("stdout is valid UTF-8");
+
+        assert!(
+            output.status.success(),
+            "`{}` failed: {}",
+            with_format.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        serde_json::from_str(&stdout).unwrap_or_else(|e| {
+            panic!(
+                "`{}` did not write JSON alone to stdout ({e}):\n{stdout}",
+                with_format.join(" ")
+            )
+        })
+    }
+
+    /// Run with `-F yaml` and return the parsed stdout.
+    async fn yaml(&self, args: &[&str]) -> serde_yaml::Value {
+        let mut with_format = args.to_vec();
+        with_format.extend(["-F", "yaml"]);
+        let output = self.run(&with_format).await;
+        let stdout = String::from_utf8(output.stdout).expect("stdout is valid UTF-8");
+
+        assert!(
+            output.status.success(),
+            "`{}` failed: {}",
+            with_format.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        serde_yaml::from_str(&stdout).unwrap_or_else(|e| {
+            panic!(
+                "`{}` did not write YAML alone to stdout ({e}):\n{stdout}",
+                with_format.join(" ")
+            )
+        })
+    }
+}
+
+/// A deployable project directory: `_ricochet.toml`, package file and entrypoint.
+fn write_project(dir: &Path, toml: &str) {
+    std::fs::write(dir.join("_ricochet.toml"), toml).expect("writing _ricochet.toml");
+    std::fs::write(dir.join("renv.lock"), r#"{"R":{},"Packages":{}}"#).expect("writing renv.lock");
+    std::fs::write(dir.join("app.R"), "shiny::shinyApp(ui, server)").expect("writing app.R");
+}
+
+#[tokio::test]
+async fn app_list_writes_json_alone() {
+    let cli = Cli::new().await;
+    let payload = cli.json(&["app", "list"]).await;
+    assert_eq!(payload[0]["id"], CONTENT_ID);
+}
+
+#[tokio::test]
+async fn app_list_writes_yaml_alone() {
+    let cli = Cli::new().await;
+    let payload = cli.yaml(&["app", "list"]).await;
+    assert_eq!(
+        payload[0]["id"],
+        serde_yaml::Value::String(CONTENT_ID.into())
+    );
+}
+
+#[tokio::test]
+async fn task_list_writes_json_alone() {
+    let cli = Cli::new().await;
+    let payload = cli.json(&["task", "list"]).await;
+    assert_eq!(payload[0]["content_type"], "quarto-r");
+}
+
+#[tokio::test]
+async fn app_toml_writes_json_alone() {
+    let cli = Cli::new().await;
+    let payload = cli.json(&["app", "toml", CONTENT_ID]).await;
+    assert_eq!(payload["content_id"], CONTENT_ID);
+    assert!(
+        payload["toml"]
+            .as_str()
+            .is_some_and(|t| t.contains("[content]"))
+    );
+}
+
+#[tokio::test]
+async fn app_instances_writes_json_alone() {
+    let cli = Cli::new().await;
+    let payload = cli.json(&["app", "instances", CONTENT_ID]).await;
+    assert_eq!(payload[0]["instance_id"], INSTANCE_ID);
+}
+
+#[tokio::test]
+async fn app_stop_writes_json_alone() {
+    let cli = Cli::new().await;
+    let payload = cli.json(&["app", "stop", CONTENT_ID, INSTANCE_ID]).await;
+    assert_eq!(payload["stopped"][0], INSTANCE_ID);
+}
+
+#[tokio::test]
+async fn app_deployment_list_writes_json_alone() {
+    let cli = Cli::new().await;
+    let payload = cli.json(&["app", "deployment", "list", CONTENT_ID]).await;
+    assert_eq!(payload[0]["id"], DEPLOYMENT_ID);
+}
+
+#[tokio::test]
+async fn app_deployment_get_writes_json_alone() {
+    let cli = Cli::new().await;
+    let payload = cli.json(&["app", "deployment", "get", DEPLOYMENT_ID]).await;
+    assert_eq!(payload["content_id"], CONTENT_ID);
+}
+
+#[tokio::test]
+async fn app_env_vars_get_writes_json_alone() {
+    let cli = Cli::new().await;
+    let payload = cli.json(&["app", "env-vars", "get", CONTENT_ID]).await;
+    assert_eq!(payload[0], "DATABASE_URL");
+}
+
+#[tokio::test]
+async fn app_env_vars_set_writes_json_alone() {
+    let cli = Cli::new().await;
+    let payload = cli
+        .json(&[
+            "app",
+            "env-vars",
+            "set",
+            "DATABASE_URL=postgres://localhost",
+            "-i",
+            CONTENT_ID,
+        ])
+        .await;
+    assert_eq!(payload[0], "DATABASE_URL");
+}
+
+#[tokio::test]
+async fn app_env_vars_replace_writes_json_alone() {
+    let cli = Cli::new().await;
+    let payload = cli
+        .json(&[
+            "app",
+            "env-vars",
+            "replace",
+            "DATABASE_URL=postgres://localhost",
+            "-i",
+            CONTENT_ID,
+            "-f",
+        ])
+        .await;
+    assert_eq!(payload[0], "DATABASE_URL");
+}
+
+#[tokio::test]
+async fn app_env_vars_delete_writes_json_alone() {
+    let cli = Cli::new().await;
+    let payload = cli
+        .json(&[
+            "app",
+            "env-vars",
+            "delete",
+            "DATABASE_URL",
+            "-i",
+            CONTENT_ID,
+            "-f",
+        ])
+        .await;
+    assert_eq!(payload, json!([]));
+}
+
+#[tokio::test]
+async fn app_settings_writes_json_alone() {
+    let cli = Cli::new().await;
+    let project = TempDir::new().unwrap();
+    write_project(project.path(), LOCAL_TOML);
+    let toml_path = project.path().join("_ricochet.toml");
+
+    let payload = cli
+        .json(&["app", "settings", "-p", toml_path.to_str().unwrap()])
+        .await;
+    assert_eq!(payload["content"]["name"], "local-app");
+}
+
+#[tokio::test]
+async fn app_settings_update_writes_json_alone() {
+    let cli = Cli::new().await;
+    let project = TempDir::new().unwrap();
+    write_project(project.path(), LOCAL_TOML);
+    let toml_path = project.path().join("_ricochet.toml");
+
+    let payload = cli
+        .json(&[
+            "app",
+            "settings",
+            "update",
+            "-p",
+            toml_path.to_str().unwrap(),
+            "-f",
+        ])
+        .await;
+    assert_eq!(payload["content"]["name"], "local-app");
+}
+
+#[tokio::test]
+async fn task_invoke_writes_json_alone() {
+    let cli = Cli::new().await;
+    let payload = cli.json(&["task", "invoke", CONTENT_ID]).await;
+    assert_eq!(payload["status"], "pending");
+}
+
+#[tokio::test]
+async fn task_schedule_writes_json_alone() {
+    let cli = Cli::new().await;
+    let payload = cli
+        .json(&["task", "schedule", CONTENT_ID, "0 9 * * 1-5"])
+        .await;
+    assert_eq!(payload["schedule"], "0 9 * * 1-5");
+}
+
+#[tokio::test]
+async fn deploy_writes_json_alone() {
+    let cli = Cli::new().await;
+    let project = TempDir::new().unwrap();
+    write_project(project.path(), LOCAL_TOML);
+
+    let payload = cli
+        .json(&["deploy", project.path().to_str().unwrap()])
+        .await;
+    assert_eq!(payload["id"], CONTENT_ID);
+    assert_eq!(payload["deployment_id"], DEPLOYMENT_ID);
+}
+
+#[tokio::test]
+async fn deploy_git_writes_json_alone() {
+    let cli = Cli::new().await;
+    let payload = cli
+        .json(&["deploy", "--git", "https://github.com/org/repo"])
+        .await;
+    assert_eq!(payload["id"], CONTENT_ID);
+}
+
+#[tokio::test]
+async fn delete_writes_json_alone() {
+    let cli = Cli::new().await;
+    let payload = cli.json(&["delete", CONTENT_ID, "-f"]).await;
+    assert_eq!(payload["id"], CONTENT_ID);
+}
+
+#[tokio::test]
+async fn user_credentials_writes_json_alone() {
+    let cli = Cli::new().await;
+    let payload = cli.json(&["user", "credentials"]).await;
+    assert_eq!(payload[0]["name"], "deploy-key");
+}
+
+#[tokio::test]
+async fn config_writes_json_alone() {
+    let cli = Cli::new().await;
+    let payload = cli.json(&["config"]).await;
+    assert!(payload["config_file"].as_str().is_some());
+}
+
+#[tokio::test]
+async fn server_commands_write_json_alone() {
+    let cli = Cli::new().await;
+
+    let listed = cli.json(&["server", "list"]).await;
+    assert!(listed.is_array());
+
+    let added = cli
+        .json(&["server", "add", "staging", "https://staging.example.com"])
+        .await;
+    assert_eq!(added["name"], "staging");
+
+    let defaulted = cli.json(&["server", "set-default", "staging"]).await;
+    assert_eq!(defaulted["default_server"], "staging");
+
+    let removed = cli.json(&["server", "remove", "staging", "-f"]).await;
+    assert_eq!(removed["name"], "staging");
+}
+
+#[tokio::test]
+async fn login_and_logout_write_json_alone() {
+    let cli = Cli::new().await;
+
+    let logout = cli.json(&["logout"]).await;
+    assert_eq!(logout["logged_out"], true);
+
+    let login = cli.json(&["login", "-k", "rico_testkey123456"]).await;
+    assert_eq!(login["server"], "test");
+    assert_eq!(login["api_key"], "rico_tes...3456");
+}

--- a/tests/json_output_test.rs
+++ b/tests/json_output_test.rs
@@ -12,6 +12,11 @@ const CONTENT_ID: &str = "01K66JV2Q123456789ABCDEF";
 const DEPLOYMENT_ID: &str = "01KQZPF4Y5SRHES967VZEYY765";
 const INSTANCE_ID: &str = "01KQZMZXE17RV7TCNF3GGG24P4";
 
+/// A second item whose second instance refuses to stop.
+const PARTIAL_STOP_ID: &str = "01KR0000000000000000000000";
+const STOPPABLE_INSTANCE: &str = "01KR1111111111111111111111";
+const STUCK_INSTANCE: &str = "01KR2222222222222222222222";
+
 /// Test-only RSA public key, served so the env-var commands can encrypt.
 const TEST_PUB_PEM: &str = "-----BEGIN RSA PUBLIC KEY-----
 MIIBCgKCAQEAr1XuDE4bFt7TnYqAtiRQ9RvC2sG3s8N8zUsCvhM+mZD7mGTN47bk
@@ -134,6 +139,49 @@ fn mock_api(server: &mut Server) {
             format!("/api/v0/content/{CONTENT_ID}/instances/{INSTANCE_ID}/stop").as_str(),
         )
         .with_status(200)
+        .create();
+
+    server
+        .mock(
+            "GET",
+            format!("/api/v0/content/{PARTIAL_STOP_ID}/instances").as_str(),
+        )
+        .with_status(200)
+        .with_body(
+            json!([
+                {
+                    "instance_id": STOPPABLE_INSTANCE,
+                    "connections": 1,
+                    "created_at": "2024-01-15T10:30:00Z",
+                    "last_connection": 0
+                },
+                {
+                    "instance_id": STUCK_INSTANCE,
+                    "connections": 1,
+                    "created_at": "2024-01-15T10:30:00Z",
+                    "last_connection": 0
+                }
+            ])
+            .to_string(),
+        )
+        .create();
+
+    server
+        .mock(
+            "POST",
+            format!("/api/v0/content/{PARTIAL_STOP_ID}/instances/{STOPPABLE_INSTANCE}/stop")
+                .as_str(),
+        )
+        .with_status(200)
+        .create();
+
+    server
+        .mock(
+            "POST",
+            format!("/api/v0/content/{PARTIAL_STOP_ID}/instances/{STUCK_INSTANCE}/stop").as_str(),
+        )
+        .with_status(500)
+        .with_body("instance is wedged")
         .create();
 
     server
@@ -388,6 +436,31 @@ async fn app_stop_writes_json_alone() {
     let cli = Cli::new().await;
     let payload = cli.json(&["app", "stop", CONTENT_ID, INSTANCE_ID]).await;
     assert_eq!(payload["stopped"][0], INSTANCE_ID);
+}
+
+/// A stop that fails partway still has to report what it brought down.
+#[tokio::test]
+async fn app_stop_reports_the_instances_it_stopped_before_failing() {
+    let cli = Cli::new().await;
+    let output = cli
+        .run(&["app", "stop", PARTIAL_STOP_ID, "-F", "json"])
+        .await;
+
+    assert!(
+        !output.status.success(),
+        "a failed stop must exit non-zero, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout is valid UTF-8");
+    let payload: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout is not JSON ({e}):\n{stdout}"));
+
+    assert_eq!(payload["stopped"], json!([STOPPABLE_INSTANCE]));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains(STUCK_INSTANCE),
+        "the error should name the instance that refused to stop"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
`-F json` and `-F yaml` now put the serialised payload on stdout and nothing else, and `deploy` takes the flag like every other command.

<details>
<summary>AI Summary</summary>

## Why

An editor extension, a CI job and a shell pipeline all need `-F json` to mean "JSON on stdout, nothing else".
`deploy` had no `format` argument at all, so `ricochet deploy -F json` silently printed human text, and several commands that did take `format` interleaved status lines with the payload.

## What changed

`src/output.rs` owns `OutputFormat` and the single rule every command now follows:

```rust
format.print(&payload, || Ok(human_rendering))
```

`Json` and `Yaml` serialise the payload to stdout, `Table` calls the closure.
Building the human rendering as a `String` and printing it once means no command can interleave prose with the payload by accident.

- `deploy` and `deploy --git` take `format` and emit the deployment response as JSON, with the `📦` line, the workspace-root notices, the success line and the Links block moved to stderr or into the table rendering.
- The `_ricochet.toml` id write-back moved into `write_content_id`, so that side effect no longer hides inside a printing branch.
- `delete`, `app stop`, `app toml`, `task toml`, `server list|add|remove|set-default`, `config`, `login` and `logout` gained a `format` argument, and the commands with no natural payload emit a modelled one: `{"id": …}` for delete, `{"content_id", "stopped": [...]}` for stop, `{"server", "logged_out"}` for logout.
- `config` and `server list` share one `ConfiguredServer` view and a single `mask_api_key`, instead of masking keys in two places.
- The `--debug` bundle listing in `utils.rs` writes to stderr, so `--debug -F json` stays parseable.

Two incidental behaviour changes: `app toml` and `task toml` now honour `--server` (they resolved the default server regardless), and `login` reports the stored key as `rico_abc...mnop` rather than its first twelve characters, matching how `config` and `server list` mask.

`init`, `self update` and `generate-docs` still print human text under `-F json`.
`init` refuses to run non-interactively so no program can reach it, and #214 redesigns that surface.

## Validation

```
cargo test --all-features --workspace                     93 lib + 23 new integration tests, all green
cargo clippy --all-targets --all-features -- -D warnings   clean
cargo fmt --all --check / prek run -a / just docs-check     pass
```

`tests/json_output_test.rs` spawns the real binary against a mockito server with a throwaway `$HOME`, then asserts the exit status and parses `String::from_utf8(stdout)` as JSON with no preprocessing, once per command.
Driving the binary rather than the library functions is what catches a stray `println!` anywhere in the process.

## Noticed, not fixed

`Config::resolve_server` skips `apply_env_key_override` on the direct-URL path, so `RICOCHET_SERVER` together with `RICOCHET_API_KEY` fails with "No API key configured" unless the URL is already a configured server.
That breaks the documented environment-variable pair for CI.
It is credential resolution rather than output, so it belongs in its own change under #212; the tests here write a config file instead.

</details>
